### PR TITLE
Add embulk to development dependency for `bundle exec embulk ...`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,7 @@
 source 'https://rubygems.org/'
+
+# NOTE: Bundler.require(:runtime, :development) in spec_helper that require all dependencies
+#       but require 'embulk' will be failed. so separate it from gemspec ecosystem
+gem 'embulk', ">= 0.6", "< 1.0"
+
 gemspec

--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']
   spec.add_development_dependency 'rspec', "~> 3.2.0"
-  spec.add_development_dependency 'embulk', ">= 0.6", "< 1.0"
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
 end

--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']
   spec.add_development_dependency 'rspec', "~> 3.2.0"
+  spec.add_development_dependency 'embulk', ">= 0.6", "< 1.0"
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'pry'
 end


### PR DESCRIPTION
I'm not sure that putting embulk gem as dependency is the right way or not.
But my experience is, `bundle exec embulk ...` can be run with this change.

Maybe a little discuss needed..
