### PR TITLE
Add integration test basis

### DIFF
--- a/spec/embulk_spec.rb
+++ b/spec/embulk_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+describe Embulk do
+  describe "registerd jira as input plugin" do
+    let(:config) { <<-YAML }
+in:
+  type: jira
+    YAML
+    let(:config_file) { Tempfile.new("embulk-conf") }
+
+    before do
+      config_file.puts config
+      config_file.close
+    end
+
+    subject {
+      capture_output(:out) do
+        Embulk.run ["preview", config_file.path]
+      end
+    }
+
+    it do
+      # NOTE: can't stub `exit` so stubbing `raise`
+      # https://github.com/embulk/embulk/blob/v0.6.9/lib/embulk/command/embulk_run.rb#L335
+      allow(Embulk).to receive(:raise)
+
+      is_expected.to_not include("InputPlugin 'jira' is not found.")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "rubygems"
 require "bundler/setup"
 Bundler.require(:runtime, :development)
+require "embulk/command/embulk_run"
 
 Dir["./spec/support/**/*.rb"].each{|file| require file }
 
@@ -12,4 +13,5 @@ end
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 RSpec.configure do |config|
+  config.include StdoutAndErrCapture
 end

--- a/spec/support/stdout_and_err_capture.rb
+++ b/spec/support/stdout_and_err_capture.rb
@@ -1,0 +1,32 @@
+module StdoutAndErrCapture
+  def capture_output(output = :out, &block)
+    java_import 'java.io.PrintStream'
+    java_import 'java.io.ByteArrayOutputStream'
+    java_import 'java.lang.System'
+
+    ruby_original_stream = output == :out ? $stdout.dup : $stderr.dup
+    java_original_stream = System.send(output) # :out or :err
+    ruby_buf = StringIO.new
+    java_buf = ByteArrayOutputStream.new
+
+    case output
+    when :out
+      $stdout = ruby_buf
+    when :err
+      $stderr = ruby_buf
+    end
+    System.setOut(PrintStream.new(java_buf))
+
+    block.call
+
+    ruby_buf.string + java_buf.toString
+  ensure
+    System.setOut(java_original_stream)
+    case output
+    when :out
+      $stdout = ruby_original_stream
+    when :err
+      $stderr = ruby_original_stream
+    end
+  end
+end


### PR DESCRIPTION
Using `Embulk.run` for integration test with arbitrary config.
