### PR TITLE
Support over 50 issues input

### DIFF
--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -4,6 +4,8 @@ require "jira/api"
 module Embulk
   module Input
     class JiraInputPlugin < InputPlugin
+      PAGE_PER = 50
+
       Plugin.register_input("jira", self)
 
       def self.transaction(config, &control)
@@ -81,16 +83,24 @@ module Embulk
           config.api_version = "latest"
           config.auth_type = :basic
         end
+        @jql = task["jql"]
       end
 
       def run
-        @jira.search_issues(task["jql"]).each do |issue|
-          values = @attributes.map do |(attribute_name, type)|
-            JiraInputPluginUtils.cast(issue[attribute_name], type)
-          end
+        total_count = @jira.total_count(@jql)
+        search_count = (total_count.to_f / PAGE_PER).ceil
 
-          page_builder.add(values)
+        search_count.times do |i|
+          start_at = i * PAGE_PER
+          @jira.search_issues(@jql, start_at: start_at).each do |issue|
+            values = @attributes.map do |(attribute_name, type)|
+              JiraInputPluginUtils.cast(issue[attribute_name], type)
+            end
+
+            page_builder.add(values)
+          end
         end
+
         page_builder.finish
 
         commit_report = {}

--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -4,7 +4,7 @@ require "jira/api"
 module Embulk
   module Input
     class JiraInputPlugin < InputPlugin
-      PAGE_PER = 50
+      PER_PAGE = 50
 
       Plugin.register_input("jira", self)
 
@@ -88,10 +88,10 @@ module Embulk
 
       def run
         total_count = @jira.total_count(@jql)
-        search_count = (total_count.to_f / PAGE_PER).ceil
+        search_count = (total_count.to_f / PER_PAGE).ceil
 
         search_count.times do |i|
-          start_at = i * PAGE_PER
+          start_at = i * PER_PAGE
           @jira.search_issues(@jql, start_at: start_at).each do |issue|
             values = @attributes.map do |(attribute_name, type)|
               JiraInputPluginUtils.cast(issue[attribute_name], type)

--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -88,10 +88,8 @@ module Embulk
 
       def run
         total_count = @jira.total_count(@jql)
-        search_count = (total_count.to_f / PER_PAGE).ceil
 
-        search_count.times do |i|
-          start_at = i * PER_PAGE
+        0.step(total_count, PER_PAGE) do |start_at|
           @jira.search_issues(@jql, start_at: start_at).each do |issue|
             values = @attributes.map do |(attribute_name, type)|
               JiraInputPluginUtils.cast(issue[attribute_name], type)

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -19,7 +19,7 @@ module Jira
     end
 
     def total_count(jql)
-      Jiralicious.search(jql).num_results
+      search(jql, max_results: 1).num_results
     end
   end
 end

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -16,6 +16,9 @@ module Jira
 
     def search(jql)
       Jiralicious.search(jql)
+
+    def total_count(jql)
+      Jiralicious.search(jql).num_results
     end
   end
 end

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -8,14 +8,15 @@ module Jira
       new
     end
 
-    def search_issues(jql)
-      search(jql).issues.map do |issue|
+    def search_issues(jql, options={})
+      search(jql, options).issues.map do |issue|
         ::Jira::Issue.new(issue)
       end
     end
 
-    def search(jql)
-      Jiralicious.search(jql)
+    def search(jql, options={})
+      Jiralicious.search(jql, options)
+    end
 
     def total_count(jql)
       Jiralicious.search(jql).num_results

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -171,7 +171,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:jira_api) { Jira::Api.new }
     let(:jira_issues) { [Jira::Issue.new(field)] * total_count }
     let(:total_count) { max_result + 10 }
-    let(:max_result) { Embulk::Input::JiraInputPlugin::PAGE_PER }
+    let(:max_result) { Embulk::Input::JiraInputPlugin::PER_PAGE }
 
 
     let(:page_builder) { Object.new } # add mock later

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -199,7 +199,7 @@ describe Embulk::Input::JiraInputPlugin do
       # TODO: create stubs without each `it` expected
       allow(Jira::Api).to receive(:setup).and_return(jira_api)
 
-      [0, max_result].each do |start_at|
+      0.step(total_count, max_result) do |start_at|
         issues = jira_issues[start_at..(start_at + max_result - 1)]
         allow(jira_api).to receive(:search_issues).with(jql, start_at: start_at).and_return(issues)
       end

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -169,11 +169,15 @@ describe Embulk::Input::JiraInputPlugin do
     end
 
     let(:jira_api) { Jira::Api.new }
-    let(:jira_issues) { [Jira::Issue.new(field)] }
+    let(:jira_issues) { [Jira::Issue.new(field)] * total_count }
+    let(:total_count) { max_result + 10 }
+    let(:max_result) { Embulk::Input::JiraInputPlugin::PAGE_PER }
+
 
     let(:page_builder) { Object.new } # add mock later
     let(:task) do
       {
+        "jql" => jql,
         "attributes" => {"project.key" => "string"}
       }
     end
@@ -194,7 +198,12 @@ describe Embulk::Input::JiraInputPlugin do
     before do
       # TODO: create stubs without each `it` expected
       allow(Jira::Api).to receive(:setup).and_return(jira_api)
-      allow(jira_api).to receive(:search_issues).and_return(jira_issues)
+
+      [0, max_result].each do |start_at|
+        issues = jira_issues[start_at..(start_at + max_result - 1)]
+        allow(jira_api).to receive(:search_issues).with(jql, start_at: start_at).and_return(issues)
+      end
+      allow(jira_api).to receive(:total_count).and_return(total_count)
 
       allow(page_builder).to receive(:add).with([project_name])
       allow(page_builder).to receive(:finish)
@@ -206,7 +215,7 @@ describe Embulk::Input::JiraInputPlugin do
     end
 
     it 'page build and finish' do
-      expect(page_builder).to receive(:add).with([project_name])
+      expect(page_builder).to receive(:add).with([project_name]).exactly(total_count).times
       expect(page_builder).to receive(:finish)
       subject
     end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -1,3 +1,5 @@
+# TODO: move to spec/jira/api_spec.rb
+
 require "spec_helper"
 require "jira/api"
 
@@ -58,6 +60,21 @@ describe Jira::Api do
 
       expect(subject).to be_kind_of Array
       expect(subject.map(&:class)).to match_array [Jira::Issue, Jira::Issue]
+    end
+  end
+
+  describe "#total_count" do
+    subject { Jira::Api.new.total_count(jql) }
+
+    let(:jql) { "project=FOO" }
+    let(:results) { 5 }
+
+    before do
+      allow(Jiralicious).to receive_message_chain(:search, :num_results).and_return(results)
+    end
+
+    it do
+      expect(subject).to eq results
     end
   end
 end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -64,17 +64,25 @@ describe Jira::Api do
   end
 
   describe "#total_count" do
-    subject { Jira::Api.new.total_count(jql) }
+    subject { jira_api.total_count(jql) }
 
+    let(:jira_api) { Jira::Api.new }
     let(:jql) { "project=FOO" }
-    let(:results) { 5 }
+    let(:results) { Object.new } # add mock later
+    let(:results_count) { 5 }
 
     before do
-      allow(Jiralicious).to receive_message_chain(:search, :num_results).and_return(results)
+      allow(results).to receive(:num_results).and_return(results_count)
     end
 
-    it do
-      expect(subject).to eq results
+    it "calls Jira::Api#search with proper arguments" do
+      expect(jira_api).to receive(:search).with(jql, max_results: 1).and_return(results)
+      subject
+    end
+
+    it "returns issues count" do
+      allow(jira_api).to receive(:search).with(jql, max_results: 1).and_return(results)
+      expect(subject).to eq results_count
     end
   end
 end


### PR DESCRIPTION
Now, this plugin treats 50 issues only because of JIRA API (https://docs.atlassian.com/jira/REST/latest/#d2e965 ), so I implemented calling API with `start_at` parameter gets over 50 issues.
