### PR TITLE
Support issue id and key

### DIFF
--- a/lib/jira/issue.rb
+++ b/lib/jira/issue.rb
@@ -1,23 +1,20 @@
 module Jira
   class Issue
-    JIRA_ID = "id"
-    ISSUE_ID = "id"
-    JIRA_KEY = "jira_key"
-    ISSUE_KEY = "key"
-
     attr_reader :id, :key, :fields
 
     def initialize(attributes)
-      @id = attributes.fetch(JIRA_ID)
-      @key = attributes.fetch(JIRA_KEY)
+      @id = attributes.fetch("id")
+
+      # https://github.com/dorack/jiralicious/blob/404b7b6d5b7020f42064cf8d7a745ab02057e728/lib/jiralicious/issue.rb#L11-L12
+      @key = attributes.fetch("jira_key")
       @fields = attributes.fetch("fields")
     end
 
     def [](attribute)
       case attribute
-      when ISSUE_ID
+      when "id"
         return @id
-      when ISSUE_KEY
+      when "key"
         return @key
       end
 
@@ -37,8 +34,8 @@ module Jira
     def to_record
       record = {}
 
-      record[ISSUE_ID] = @id
-      record[ISSUE_KEY] = @key
+      record["key"] = @key
+      record["id"] = @id
 
       fields.each_pair do |key, value|
         record_key = key

--- a/lib/jira/issue.rb
+++ b/lib/jira/issue.rb
@@ -18,16 +18,16 @@ module Jira
         return key
       end
 
-      fields = @fields
-      attribute.split('.').each do |chunk|
-        fields = fields[chunk]
-        return fields if fields.nil?
+      chunk = fields
+      attribute.split('.').each do |key|
+        chunk = chunk[key]
+        return chunk if chunk.nil?
       end
 
-      if fields.is_a?(Array) || fields.is_a?(Hash)
-        fields.to_json.to_s
+      if chunk.is_a?(Array) || chunk.is_a?(Hash)
+        chunk.to_json.to_s
       else
-        fields
+        chunk
       end
     end
 

--- a/lib/jira/issue.rb
+++ b/lib/jira/issue.rb
@@ -13,9 +13,9 @@ module Jira
     def [](attribute)
       case attribute
       when "id"
-        return @id
+        return id
       when "key"
-        return @key
+        return key
       end
 
       fields = @fields
@@ -34,8 +34,8 @@ module Jira
     def to_record
       record = {}
 
-      record["key"] = @key
-      record["id"] = @id
+      record["id"] = id
+      record["key"] = key
 
       fields.each_pair do |key, value|
         record_key = key

--- a/lib/jira/issue.rb
+++ b/lib/jira/issue.rb
@@ -2,11 +2,14 @@ module Jira
   class Issue
     JIRA_ID = "id"
     ISSUE_ID = "id"
+    JIRA_KEY = "jira_key"
+    ISSUE_KEY = "key"
 
-    attr_reader :id, :fields
+    attr_reader :id, :key, :fields
 
     def initialize(attributes)
       @id = attributes.fetch(JIRA_ID)
+      @key = attributes.fetch(JIRA_KEY)
       @fields = attributes.fetch("fields")
     end
 
@@ -14,6 +17,8 @@ module Jira
       case attribute
       when ISSUE_ID
         return @id
+      when ISSUE_KEY
+        return @key
       end
 
       fields = @fields
@@ -33,6 +38,7 @@ module Jira
       record = {}
 
       record[ISSUE_ID] = @id
+      record[ISSUE_KEY] = @key
 
       fields.each_pair do |key, value|
         record_key = key

--- a/lib/jira/issue.rb
+++ b/lib/jira/issue.rb
@@ -1,12 +1,21 @@
 module Jira
   class Issue
-    attr_reader :fields
+    JIRA_ID = "id"
+    ISSUE_ID = "id"
+
+    attr_reader :id, :fields
 
     def initialize(attributes)
+      @id = attributes.fetch(JIRA_ID)
       @fields = attributes.fetch("fields")
     end
 
     def [](attribute)
+      case attribute
+      when ISSUE_ID
+        return @id
+      end
+
       fields = @fields
       attribute.split('.').each do |chunk|
         fields = fields[chunk]
@@ -22,6 +31,8 @@ module Jira
 
     def to_record
       record = {}
+
+      record[ISSUE_ID] = @id
 
       fields.each_pair do |key, value|
         record_key = key

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -99,6 +99,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:field) do
       {
         "id" => "100",
+        "jira_key" => "FOO-100",
         "fields" =>
         {
           "project" => {
@@ -122,6 +123,7 @@ describe Embulk::Input::JiraInputPlugin do
         "auth_type" => "basic",
         "columns" => [
           {name: "id", type: :long},
+          {name: "key", type: :string},
           {name: "project.name", type: :string},
           {name: "comment", type: :string}
         ]
@@ -173,7 +175,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:jira_api) { Jira::Api.new }
     let(:jira_issues) do
       (1..total_count).map do |i|
-        attributes = field.merge("id" => i.to_s)
+        attributes = field.merge("id" => i.to_s, "jira_key" => "FOO-#{i}")
 
         Jira::Issue.new(attributes)
       end

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -95,8 +95,8 @@ describe Embulk::Input::JiraInputPlugin do
     let(:config) { Object.new } # add mock later
 
     let(:jira_api) { Jira::Api.new }
-    let(:jira_issues) { [Jira::Issue.new(field)] }
-    let(:field) do
+    let(:jira_issues) { [Jira::Issue.new(attributes)] }
+    let(:attributes) do
       {
         "id" => "100",
         "jira_key" => "FOO-100",

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -98,6 +98,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:jira_issues) { [Jira::Issue.new(field)] }
     let(:field) do
       {
+        "id" => "100",
         "fields" =>
         {
           "project" => {
@@ -120,6 +121,7 @@ describe Embulk::Input::JiraInputPlugin do
         "api_version" => "latest",
         "auth_type" => "basic",
         "columns" => [
+          {name: "id", type: :long},
           {name: "project.name", type: :string},
           {name: "comment", type: :string}
         ]
@@ -169,7 +171,14 @@ describe Embulk::Input::JiraInputPlugin do
     end
 
     let(:jira_api) { Jira::Api.new }
-    let(:jira_issues) { [Jira::Issue.new(field)] * total_count }
+    let(:jira_issues) do
+      (1..total_count).map do |i|
+        attributes = field.merge("id" => i.to_s)
+
+        Jira::Issue.new(attributes)
+      end
+    end
+
     let(:total_count) { max_result + 10 }
     let(:max_result) { Embulk::Input::JiraInputPlugin::PER_PAGE }
 

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -175,7 +175,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:jira_api) { Jira::Api.new }
     let(:jira_issues) do
       (1..total_count).map do |i|
-        attributes = field.merge("id" => i.to_s, "jira_key" => "FOO-#{i}")
+        attributes = fields.merge("id" => i.to_s, "jira_key" => "FOO-#{i}")
 
         Jira::Issue.new(attributes)
       end
@@ -193,7 +193,7 @@ describe Embulk::Input::JiraInputPlugin do
       }
     end
 
-    let(:field) do
+    let(:fields) do
       {
         "fields" =>
         {

--- a/spec/jira/issue_spec.rb
+++ b/spec/jira/issue_spec.rb
@@ -7,6 +7,7 @@ describe Jira::Issue do
       let(:issue_attributes) do
         {
           "id" => 1,
+          "jira_key" => "PRO_1",
           "fields" =>
           {
             "summary" => "jira issue",
@@ -20,6 +21,10 @@ describe Jira::Issue do
 
       it "has @id with argument['id']" do
         expect(Jira::Issue.new(issue_attributes).id).to eq issue_attributes["id"]
+      end
+
+      it "has @key with argument['jira_key']" do
+        expect(Jira::Issue.new(issue_attributes).key).to eq issue_attributes["jira_key"]
       end
 
       it "has @field with argument['fields']" do
@@ -44,6 +49,7 @@ describe Jira::Issue do
     let(:issue_attributes) do
       {
         "id" => "1",
+        "jira_key" => "FOO-1",
         "fields" => {
           "summary" => "jira issue",
           "project" => project_attribute,
@@ -73,6 +79,14 @@ describe Jira::Issue do
 
       it "returns issue id" do
         expect(subject).to eq "1"
+      end
+    end
+
+    context 'key' do
+      let(:attribute_name) { 'key' }
+
+      it "returns issue key" do
+        expect(subject).to eq "FOO-1"
       end
     end
 
@@ -127,6 +141,7 @@ describe Jira::Issue do
     let(:issue_fields) do
       {
         "id" => 1,
+        "jira_key" => "FOO-1",
         "fields" => {
           "summary" => "jira issue",
           "project" => {
@@ -150,6 +165,7 @@ describe Jira::Issue do
     let(:expected) do
       {
         "id" => 1,
+        "key" => "FOO-1",
         "summary" => "jira issue",
         "project.id" => "FOO",
         "labels" => "[\"Feature\",\"WantTo\"]",

--- a/spec/jira/issue_spec.rb
+++ b/spec/jira/issue_spec.rb
@@ -7,7 +7,7 @@ describe Jira::Issue do
       let(:issue_attributes) do
         {
           "id" => 1,
-          "jira_key" => "PRO_1",
+          "jira_key" => "PRO-1",
           "fields" =>
           {
             "summary" => "jira issue",

--- a/spec/jira/issue_spec.rb
+++ b/spec/jira/issue_spec.rb
@@ -135,10 +135,10 @@ describe Jira::Issue do
 
   describe "#to_record" do
     subject do
-      Jira::Issue.new(issue_fields).to_record
+      Jira::Issue.new(issue_attributes).to_record
     end
 
-    let(:issue_fields) do
+    let(:issue_attributes) do
       {
         "id" => 1,
         "jira_key" => "FOO-1",

--- a/spec/jira/issue_spec.rb
+++ b/spec/jira/issue_spec.rb
@@ -5,7 +5,9 @@ describe Jira::Issue do
   describe ".initialize" do
     context "when argument has 'fields' key" do
       let(:issue_attributes) do
-        {"fields" =>
+        {
+          "id" => 1,
+          "fields" =>
           {
             "summary" => "jira issue",
             "project" =>
@@ -14,6 +16,10 @@ describe Jira::Issue do
             },
           }
         }
+      end
+
+      it "has @id with argument['id']" do
+        expect(Jira::Issue.new(issue_attributes).id).to eq issue_attributes["id"]
       end
 
       it "has @field with argument['fields']" do
@@ -36,8 +42,9 @@ describe Jira::Issue do
     subject { Jira::Issue.new(issue_attributes)[attribute_name] }
 
     let(:issue_attributes) do
-      {"fields" =>
-        {
+      {
+        "id" => "1",
+        "fields" => {
           "summary" => "jira issue",
           "project" => project_attribute,
           "labels" =>
@@ -59,6 +66,14 @@ describe Jira::Issue do
       {
         "key" => "FOO",
       }
+    end
+
+    context 'id' do
+      let(:attribute_name) { 'id' }
+
+      it "returns issue id" do
+        expect(subject).to eq "1"
+      end
     end
 
     context 'summary' do
@@ -110,8 +125,9 @@ describe Jira::Issue do
     end
 
     let(:issue_fields) do
-      {"fields" =>
-        {
+      {
+        "id" => 1,
+        "fields" => {
           "summary" => "jira issue",
           "project" => {
             "id" => "FOO",
@@ -133,6 +149,7 @@ describe Jira::Issue do
 
     let(:expected) do
       {
+        "id" => 1,
         "summary" => "jira issue",
         "project.id" => "FOO",
         "labels" => "[\"Feature\",\"WantTo\"]",

--- a/spec/jira/issue_spec.rb
+++ b/spec/jira/issue_spec.rb
@@ -27,7 +27,7 @@ describe Jira::Issue do
         expect(Jira::Issue.new(issue_attributes).key).to eq issue_attributes["jira_key"]
       end
 
-      it "has @field with argument['fields']" do
+      it "has @fields with argument['fields']" do
         expect(Jira::Issue.new(issue_attributes).fields).to eq issue_attributes["fields"]
       end
     end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -31,6 +31,7 @@ describe Jira::Api do
     let(:results) do
       [
         {
+          "id" => 1,
           "fields" =>
           {
             "summary" => "issue summary",
@@ -41,6 +42,7 @@ describe Jira::Api do
           }
         },
         {
+          "id" => 2,
           "fields" =>
           {
             "summary" => "jira issue",

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -32,6 +32,7 @@ describe Jira::Api do
       [
         {
           "id" => 1,
+          "jira_key" => "FOO-1",
           "fields" =>
           {
             "summary" => "issue summary",
@@ -43,6 +44,7 @@ describe Jira::Api do
         },
         {
           "id" => 2,
+          "jira_key" => "FOO-2",
           "fields" =>
           {
             "summary" => "jira issue",


### PR DESCRIPTION
I implemented JiraImputPlugin supports issue.id (e.g. "11002") and issue.key (e.g. "PRO-11002"). JIRA issus has `fields` attribute, but this attribute doesn't have `id` and `key` key, so I implemented `issue[]` supports parameter as `id` or `key`.
