### PR TITLE
Display progress

### DIFF
--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -94,8 +94,10 @@ module Embulk
 
       def run
         total_count = @jira.total_count(@jql)
+        last_page = (total_count.to_f / PER_PAGE).ceil
 
-        0.step(total_count, PER_PAGE) do |start_at|
+        0.step(total_count, PER_PAGE).with_index(1) do |start_at, page|
+          logger.debug "Fetching #{page} / #{last_page} page"
           @jira.search_issues(@jql, start_at: start_at).each do |issue|
             values = @attributes.map do |(attribute_name, type)|
               JiraInputPluginUtils.cast(issue[attribute_name], type)

--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -1,5 +1,7 @@
 require "embulk/input/jira-input-plugin-utils"
 require "jira/api"
+require "logger"
+require "time"
 
 module Embulk
   module Input
@@ -107,6 +109,21 @@ module Embulk
 
         commit_report = {}
         return commit_report
+      end
+
+      def self.logger
+        @logger ||=
+          begin
+            logger = Logger.new($stdout)
+            logger.formatter = proc do |severity, datetime, progname, msg|
+              "#{datetime.strftime("%Y-%m-%d %H:%M:%S.%L %z")} [#{severity}] #{msg}\n"
+            end
+            logger
+          end
+      end
+
+      def logger
+        self.class.logger
       end
     end
   end

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -169,7 +169,11 @@ describe Embulk::Input::JiraInputPlugin do
 
   describe "#run" do
     subject do
-      Embulk::Input::JiraInputPlugin.new(task, nil, nil, page_builder).run
+      result = nil
+      capture_output(:out) do
+        result = Embulk::Input::JiraInputPlugin.new(task, nil, nil, page_builder).run
+      end
+      result
     end
 
     let(:jira_api) { Jira::Api.new }
@@ -243,5 +247,22 @@ describe Embulk::Input::JiraInputPlugin do
     it "returns VERSION file content without line-break" do
       expect(subject).to eq File.read(version_file_path).strip
     end
+  end
+
+  describe ".logger" do
+    let(:logger) { Embulk::Input::JiraInputPlugin.logger }
+
+    subject { logger }
+
+    it { is_expected.to be_a(Logger) }
+  end
+
+  describe "#logger" do
+    let(:instance) { Embulk::Input::JiraInputPlugin.new({}, nil, nil, nil) }
+    let(:logger) { instance.logger }
+
+    subject { logger }
+
+    it { is_expected.to be_a(Logger) }
   end
 end


### PR DESCRIPTION
Fix #16 
Display as below:

``` console
$ embulk run foo.yml
2015-06-03 16:11:26.513 +0900: Embulk v0.6.9
2015-06-03 16:11:30.896 +0900 [INFO] (transaction): {done:  0 / 1, running: 0}
2015-06-03 16:11:30.953 +0900 [INFO] (task-0000): Writing local file './sample.000.00.csv'
2015-06-03 16:11:32.840 +0900 [DEBUG] Fetching 1 / 1 page
2015-06-03 16:11:44.502 +0900 [INFO] (transaction): {done:  1 / 1, running: 0}
2015-06-03 16:11:44.527 +0900 [INFO] (main): Committed.
2015-06-03 16:11:44.527 +0900 [INFO] (main): Next config diff: {"in":{},"out":{}}
```
