### PR TITLE
Add timeout and retry for JIRA API search

### DIFF
--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -4,7 +4,8 @@ require "timeout"
 
 module Jira
   class Api
-    SEARCH_TIMEOUT = 60
+    SEARCH_TIMEOUT = 5
+    SEARCH_ISSUES_TIMEOUT = 60
     SEARCH_RETRY_TIMES = 10
 
     def self.setup(&block)
@@ -13,27 +14,37 @@ module Jira
     end
 
     def search_issues(jql, options={})
-      search(jql, options).issues.map do |issue|
-        ::Jira::Issue.new(issue)
+      timeout_and_retry(SEARCH_ISSUES_TIMEOUT, SEARCH_RETRY_TIMES) do
+        search(jql, options).issues.map do |issue|
+          ::Jira::Issue.new(issue)
+        end
       end
     end
 
     def search(jql, options={})
-      times = 1
-      begin
-        Timeout.timeout(SEARCH_TIMEOUT) do
-          Jiralicious.search(jql, options)
-        end
-      rescue Timeout::Error
-        times += 1
-        sleep times # retry after some seconds for JIRA API perhaps under the overload
-        raise "JIRA API was too many timeouts" if times > SEARCH_RETRY_TIMES
-        retry
+      timeout_and_retry(SEARCH_TIMEOUT, SEARCH_RETRY_TIMES) do
+        Jiralicious.search(jql, options)
       end
     end
 
     def total_count(jql)
       search(jql, max_results: 1).num_results
+    end
+
+    private
+
+    def timeout_and_retry(wait, retry_times = 10, &block)
+      times = 1
+      begin
+        Timeout.timeout(wait) do
+          yield
+        end
+      rescue Timeout::Error => e
+        times += 1
+        sleep times # retry after some seconds for JIRA API perhaps under the overload
+        raise e if times > retry_times
+        retry
+      end
     end
   end
 end

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -6,7 +6,7 @@ module Jira
   class Api
     SEARCH_TIMEOUT_SECONDS = 5
     SEARCH_ISSUES_TIMEOUT_SECONDS = 60
-    SEARCH_RETRY_TIMES_DEFAULT = 10
+    DEFAULT_SEARCH_RETRY_TIMES = 10
 
     def self.setup(&block)
       Jiralicious.configure(&block)
@@ -33,7 +33,7 @@ module Jira
 
     private
 
-    def timeout_and_retry(wait, retry_times = SEARCH_RETRY_TIMES_DEFAULT, &block)
+    def timeout_and_retry(wait, retry_times = DEFAULT_SEARCH_RETRY_TIMES, &block)
       count = 1
       begin
         Timeout.timeout(wait) do

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -34,15 +34,15 @@ module Jira
     private
 
     def timeout_and_retry(wait, retry_times = SEARCH_RETRY_TIMES_DEFAULT, &block)
-      times = 1
+      count = 1
       begin
         Timeout.timeout(wait) do
           yield
         end
       rescue Timeout::Error => e
-        times += 1
-        sleep times # retry after some seconds for JIRA API perhaps under the overload
-        raise e if times > retry_times
+        count += 1
+        sleep count # retry after some seconds for JIRA API perhaps under the overload
+        raise e if count > retry_times
         retry
       end
     end

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -6,7 +6,7 @@ module Jira
   class Api
     SEARCH_TIMEOUT = 5
     SEARCH_ISSUES_TIMEOUT = 60
-    SEARCH_RETRY_TIMES = 10
+    SEARCH_RETRY_TIMES_DEFAULT = 10
 
     def self.setup(&block)
       Jiralicious.configure(&block)
@@ -14,7 +14,7 @@ module Jira
     end
 
     def search_issues(jql, options={})
-      timeout_and_retry(SEARCH_ISSUES_TIMEOUT, SEARCH_RETRY_TIMES) do
+      timeout_and_retry(SEARCH_ISSUES_TIMEOUT) do
         search(jql, options).issues.map do |issue|
           ::Jira::Issue.new(issue)
         end
@@ -22,7 +22,7 @@ module Jira
     end
 
     def search(jql, options={})
-      timeout_and_retry(SEARCH_TIMEOUT, SEARCH_RETRY_TIMES) do
+      timeout_and_retry(SEARCH_TIMEOUT) do
         Jiralicious.search(jql, options)
       end
     end
@@ -33,7 +33,7 @@ module Jira
 
     private
 
-    def timeout_and_retry(wait, retry_times = 10, &block)
+    def timeout_and_retry(wait, retry_times = SEARCH_RETRY_TIMES_DEFAULT, &block)
       times = 1
       begin
         Timeout.timeout(wait) do

--- a/lib/jira/api.rb
+++ b/lib/jira/api.rb
@@ -4,8 +4,8 @@ require "timeout"
 
 module Jira
   class Api
-    SEARCH_TIMEOUT = 5
-    SEARCH_ISSUES_TIMEOUT = 60
+    SEARCH_TIMEOUT_SECONDS = 5
+    SEARCH_ISSUES_TIMEOUT_SECONDS = 60
     SEARCH_RETRY_TIMES_DEFAULT = 10
 
     def self.setup(&block)
@@ -14,7 +14,7 @@ module Jira
     end
 
     def search_issues(jql, options={})
-      timeout_and_retry(SEARCH_ISSUES_TIMEOUT) do
+      timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS) do
         search(jql, options).issues.map do |issue|
           ::Jira::Issue.new(issue)
         end
@@ -22,7 +22,7 @@ module Jira
     end
 
     def search(jql, options={})
-      timeout_and_retry(SEARCH_TIMEOUT) do
+      timeout_and_retry(SEARCH_TIMEOUT_SECONDS) do
         Jiralicious.search(jql, options)
       end
     end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -32,8 +32,8 @@ describe Jira::Api do
         allow(api).to receive(:sleep)
       end
 
-      it "retry SEARCH_RETRY_TIMES times then raise error" do
-        expect(Timeout).to receive(:timeout).exactly(Jira::Api::SEARCH_RETRY_TIMES_DEFAULT)
+      it "retry DEFAULT_SEARCH_RETRY_TIMES times then raise error" do
+        expect(Timeout).to receive(:timeout).exactly(Jira::Api::DEFAULT_SEARCH_RETRY_TIMES)
         expect { subject }.to raise_error
       end
     end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -18,11 +18,24 @@ describe Jira::Api do
 
   describe "#search" do
     let(:jql) { "project=FOO" }
+    let(:api) { Jira::Api.new }
 
-    subject { Jira::Api.new.search(jql) }
+    subject { api.search(jql) }
 
     it do
       allow(Jiralicious).to receive(:search).with(jql)
+    end
+
+    describe "retry and timeout" do
+      before do
+        allow(Timeout).to receive(:timeout) { raise Timeout::Error }
+        allow(api).to receive(:sleep)
+      end
+
+      it "retry SEARCH_RETRY_TIMES times then raise error" do
+        expect(Timeout).to receive(:timeout).exactly(Jira::Api::SEARCH_RETRY_TIMES)
+        expect { subject }.to raise_error
+      end
     end
   end
 

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -102,4 +102,28 @@ describe Jira::Api do
       expect(subject).to eq results_count
     end
   end
+
+  describe "#timeout_and_retry" do
+    let(:wait) { 1 }
+    let(:retry_times) { 3 }
+    let(:jira_api) { Jira::Api.new }
+    let(:block) { proc{ "it works" } }
+
+    subject { jira_api.send(:timeout_and_retry, wait, retry_times, &block) }
+
+    before do
+      allow(jira_api).to receive(:sleep)
+    end
+
+    it "return given block result if timeout is not occured" do
+      expect(subject).to eq block.call
+    end
+
+    it "Always timeout, raise error after N times retry" do
+      allow(Timeout).to receive(:timeout) { raise Timeout::Error }
+
+      expect(Timeout).to receive(:timeout).with(wait).exactly(retry_times).times
+      expect { subject }.to raise_error(Timeout::Error)
+    end
+  end
 end

--- a/spec/jira_api_spec.rb
+++ b/spec/jira_api_spec.rb
@@ -33,7 +33,7 @@ describe Jira::Api do
       end
 
       it "retry SEARCH_RETRY_TIMES times then raise error" do
-        expect(Timeout).to receive(:timeout).exactly(Jira::Api::SEARCH_RETRY_TIMES)
+        expect(Timeout).to receive(:timeout).exactly(Jira::Api::SEARCH_RETRY_TIMES_DEFAULT)
         expect { subject }.to raise_error
       end
     end


### PR DESCRIPTION
Fix #17 

Sometimes JIRA API is slow, so give up the embulk running if API request take a long time.
