### PR TITLE
Expand JSON for guess

### DIFF
--- a/lib/embulk/input/jira/issue.rb
+++ b/lib/embulk/input/jira/issue.rb
@@ -45,11 +45,10 @@ module Embulk
             case fields
             when Array
               values = fields.map do |field|
-                case field
-                when NilClass, Hash, Array
-                  field.to_json
-                else
+                if field.is_a?(String)
                   field.to_s
+                else
+                  field.to_json
                 end
               end
 

--- a/lib/embulk/input/jira/issue.rb
+++ b/lib/embulk/input/jira/issue.rb
@@ -25,6 +25,19 @@ module Embulk
           fetch(fields, attribute_keys)
         end
 
+        def to_record
+          @record = {}
+
+          @record["id"] = id
+          @record["key"] = key
+
+          generate_record(fields, "")
+
+          @record
+        end
+
+        private
+
         def fetch(fields, keys)
           return fields if fields.nil? || (fields.is_a?(Array) && fields.empty?)
 
@@ -63,19 +76,6 @@ module Embulk
             fetch(fields[target_key], keys)
           end
         end
-
-        def to_record
-          @record = {}
-
-          @record["id"] = id
-          @record["key"] = key
-
-          generate_record(fields, "")
-
-          @record
-        end
-
-        private
 
         def generate_record(value, prefix_key)
           case value

--- a/lib/embulk/input/jira/issue.rb
+++ b/lib/embulk/input/jira/issue.rb
@@ -34,32 +34,68 @@ module Embulk
         end
 
         def to_record
-          record = {}
+          @record = {}
 
-          record["id"] = id
-          record["key"] = key
+          @record["id"] = id
+          @record["key"] = key
 
-          fields.each_pair do |key, value|
-            record_key = key
-            record_value = value.to_json.to_s
+          generate_record(fields, "")
 
-            case value
-            when String
-              record_value = value
-            when Hash
-              if value.keys.include?("name")
-                record_key += ".name"
-                record_value = value["name"]
-              elsif value.keys.include?("id")
-                record_key += ".id"
-                record_value = value["id"]
-              end
+          @record
+        end
+
+        private
+
+        def generate_record(value, prefix_key)
+          case value
+          when Hash
+            # NOTE: If you want to flatten JSON completely, please
+            # remove this if...end and #add_heuristic_value.
+            if prefix_key.count(".") > 1
+              add_heuristic_value(value, prefix_key)
+              return
             end
 
-            record[record_key] = record_value
+            value.each_pair do |_key, _value|
+              generate_record(_value, record_key(prefix_key, _key))
+            end
+          when Array
+            if value.empty? || value.any? {|v| !v.is_a?(Hash) }
+              @record[prefix_key] = "\"#{value.map(&:to_s).join(',')}\""
+              return
+            end
+
+            # gathering values from each Hash
+            keys = value.map(&:keys).inject([]) {|sum, key| sum + key }.uniq
+            values = value.inject({}) do |sum, elem|
+              keys.each {|key| sum[key] = (sum[key] || []) << elem[key] }
+              sum
+            end
+
+            generate_record(values, prefix_key)
+          else
+            @record[prefix_key] = value
+          end
+        end
+
+        def record_key(prefix, key)
+          return key if prefix.empty?
+
+          "#{prefix}.#{key}"
+        end
+
+        def add_heuristic_value(hash, prefix_key)
+          heuristic_values = hash.select do |key, value|
+            ["name", "key", "id"].include?(key) && !value.nil?
           end
 
-          record
+          if heuristic_values.empty?
+            @record[prefix_key] = hash.to_json
+          else
+            heuristic_values.each do |key, value|
+              @record[record_key(prefix_key, key)] = value
+            end
+          end
         end
       end
     end

--- a/lib/embulk/input/jira_input_plugin_utils.rb
+++ b/lib/embulk/input/jira_input_plugin_utils.rb
@@ -1,5 +1,27 @@
 # This module contains methods for Plugin.
 
+module Embulk::Guess
+  module SchemaGuess
+    class << self
+
+      # NOTE: Original #from_hash_records uses keys of the first record only,
+      #       but JSON from JIRA API has fields which of value is sometimes nil,
+      #       sometimes JSON,
+      #       so the first record doesn't have all key for guess always.
+      # original Embulk::Guess::SchemaGuess is https://github.com/embulk/embulk/blob/57b42c31d1d539177e1e818f294550cde5b69e1f/lib/embulk/guess/schema_guess.rb#L16-L24
+      def from_hash_records(array_of_hash)
+        array_of_hash = Array(array_of_hash)
+        if array_of_hash.empty?
+          raise "SchemaGuess Can't guess schema from no records"
+        end
+        column_names = array_of_hash.map(&:keys).inject([]) {|r, a| r + a }.uniq.sort
+        samples = array_of_hash.to_a.map {|hash| column_names.map {|name| hash[name] } }
+        from_array_records(column_names, samples)
+      end
+    end
+  end
+end
+
 module Embulk
   module Input
     module JiraInputPluginUtils

--- a/spec/embulk/input/jira-input-plugin-utils_spec.rb
+++ b/spec/embulk/input/jira-input-plugin-utils_spec.rb
@@ -8,15 +8,17 @@ describe Embulk::Input::JiraInputPluginUtils do
 
     let(:records) do
       [
-        {"project_key" => "FOO", "comment.total" => 3, "created" => "2015-03-01T00:12:00"}
+        {"project.key" => "FOO-1", "comment.total" => 3, "created" => "2015-03-01T00:12:00"},
+        {"project.id" => "1", "project.key" => "FOO", "comment.total" => 3, "created" => "2015-03-01T00:12:00"}
       ]
     end
 
     let(:expected) do
       [
-        {name: "project_key", type: :string},
         {name: "comment.total", type: :long},
-        {name: "created", type: :timestamp, format: "%Y-%m-%dT%H:%M:%S"}
+        {name: "created", type: :timestamp, format: "%Y-%m-%dT%H:%M:%S"},
+        {name: "project.id", type: :long},
+        {name: "project.key", type: :string},
       ]
     end
 

--- a/spec/embulk/input/jira/issue_spec.rb
+++ b/spec/embulk/input/jira/issue_spec.rb
@@ -49,85 +49,97 @@ describe Embulk::Input::Jira::Issue do
       {
         "id" => "1",
         "jira_key" => "FOO-1",
-        "fields" => {
-          "summary" => "jira issue",
-          "project" => project_attribute,
-          "labels" =>
-          [
-            "Feature",
-            "WantTo"
-          ],
-          "priority" => {
-            "iconUrl" => "https://jira-api/images/icon.png",
-            "name" => "Must",
-            "id" => "1"
-          },
-          "customfield_1" => nil,
+        "fields" => fields_attributes
+      }
+    end
+
+    context "when target attribute_name is especially key" do
+      let(:fields_attributes) { {} }
+
+      context 'id' do
+        let(:attribute_name) { 'id' }
+
+        it "returns issue id" do
+          expect(subject).to eq "1"
+        end
+      end
+
+      context 'key' do
+        let(:attribute_name) { 'key' }
+
+        it "returns issue key" do
+          expect(subject).to eq "FOO-1"
+        end
+      end
+    end
+
+    context "when fields_attributes is `{'hoge' => 'fuga'}` and attribute_name is 'hoge'" do
+      let(:fields_attributes) do
+        {'hoge' => 'fuga'}
+      end
+
+      let(:attribute_name) { 'hoge' }
+
+      it "returns 'fuga'" do
+        expect(subject).to eq "fuga"
+      end
+    end
+
+    context "when fields_attributes is `{'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}`" do
+      let(:fields_attributes) do
+        {'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}
+      end
+
+      context "when attribute_name is 'hoge'" do
+        let(:attribute_name) { 'hoge' }
+
+        it "returns hoge's JSON" do
+          expect(subject).to eq({'fuga' => 'piyo', 'foo' => 'bar'}.to_json)
+        end
+      end
+
+      context "when attribute_name is 'hoge.fuga'" do
+        let(:attribute_name) { 'hoge.fuga' }
+
+        it "returns 'piyo'" do
+          expect(subject).to eq 'piyo'
+        end
+      end
+    end
+
+    context "when fields_attributes is `{'hoge' => [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}]}`" do
+      let(:fields_attributes) do
+        {'hoge' => [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}]}
+      end
+
+      context "when attribute_name is 'hoge'" do
+        let(:attribute_name) { 'hoge' }
+
+        it "returns JSON array" do
+          expect(subject).to eq [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}].to_json
+        end
+      end
+
+      context "when attribute_name is 'hoge.bar'" do
+        let(:attribute_name) { 'hoge.bar' }
+
+        it "returns CSV values assigned by 'bar' key" do
+          expect(subject).to eq 'piyo1,piyo2'
+        end
+      end
+    end
+
+    context "when fields_attributes is `{'hoge' => ['elem1', 'elem2', 'elem3']}` and attribute_name is 'hoge'" do
+      let(:fields_attributes) do
+        {
+          'hoge' => ['elem1', 'elem2', 'elem3'],
         }
-      }
-    end
-
-    let(:project_attribute) do
-      {
-        "key" => "FOO",
-      }
-    end
-
-    context 'id' do
-      let(:attribute_name) { 'id' }
-
-      it "returns issue id" do
-        expect(subject).to eq "1"
-      end
-    end
-
-    context 'key' do
-      let(:attribute_name) { 'key' }
-
-      it "returns issue key" do
-        expect(subject).to eq "FOO-1"
-      end
-    end
-
-    context 'summary' do
-      let(:attribute_name) { 'summary' }
-
-      it "returns issue summary" do
-        expect(subject).to eq 'jira issue'
-      end
-    end
-
-    context 'project.key' do
-      let(:attribute_name) { 'project.key' }
-
-      context "when project is not nil" do
-        it "returns issue's project key" do
-          expect(subject).to eq 'FOO'
-        end
       end
 
-      context "when project is nil" do
-        let(:project_attribute) { nil }
+      let(:attribute_name) { 'hoge' }
 
-        it "returns nil" do
-          expect(subject).to be_nil
-        end
-      end
-    end
-
-    context 'labels' do
-      let(:attribute_name) { 'labels' }
-
-      it "returns issue's labels JSON string" do
-        expect(subject).to eq '["Feature","WantTo"]'
-      end
-    end
-
-    context 'priority' do
-      let(:attribute_name) { 'priority' }
-
-      it "returns issue's priority JSON string" do
-        expect(subject).to eq '{"iconUrl":"https://jira-api/images/icon.png","name":"Must","id":"1"}'
+      it "returns CSV values assigned by 'hoge'" do
+        expect(subject).to eq 'elem1,elem2,elem3'
       end
     end
   end

--- a/spec/embulk/input/jira/issue_spec.rb
+++ b/spec/embulk/input/jira/issue_spec.rb
@@ -137,44 +137,194 @@ describe Embulk::Input::Jira::Issue do
       Embulk::Input::Jira::Issue.new(issue_attributes).to_record
     end
 
+    shared_examples 'return guessed record' do
+      it do
+        expect(subject).to eq expected_record
+      end
+    end
+
     let(:issue_attributes) do
-      {
-        "id" => 1,
-        "jira_key" => "FOO-1",
-        "fields" => {
-          "summary" => "jira issue",
-          "project" => {
-            "id" => "FOO",
-          },
-          "labels" =>
-          [
-            "Feature",
-            "WantTo"
-          ],
-          "priority" => {
-            "iconUrl" => "https://jira-api/images/icon.png",
-            "name" => "Must",
-            "id" => "1"
-          },
-          "customfield_1" => nil,
-        }
-      }
+      {"jira_key" => "FOO-1", "id" => "1", "fields" => fields_attributes}
     end
 
-    let(:expected) do
+    let(:expected_record) do
       {
-        "id" => 1,
         "key" => "FOO-1",
-        "summary" => "jira issue",
-        "project.id" => "FOO",
-        "labels" => "[\"Feature\",\"WantTo\"]",
-        "priority.name" => "Must",
-        "customfield_1" => "null"
-      }
+        "id" => "1"
+      }.merge(exptected_record_from_fields)
     end
 
-    it 'return guessed record' do
-      expect(subject).to eq expected
+    context "when fields_attributes is `{'hoge' => 'fuga'}`" do
+      let(:fields_attributes) do
+        {'hoge' => 'fuga'}
+      end
+
+      let(:exptected_record_from_fields) do
+        {'hoge' => 'fuga'}
+      end
+
+      it_behaves_like "return guessed record"
+    end
+
+    context "when fields_attributes is `{'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}`" do
+      let(:fields_attributes) do
+        {'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}
+      end
+
+      let(:exptected_record_from_fields) do
+        {
+          "hoge.fuga" => "piyo",
+          "hoge.foo" => "bar"
+        }
+      end
+
+      it_behaves_like "return guessed record"
+    end
+
+    context "when fields_attributes is `{'hoge' => {'fuga' => {'piyo' => last_child}}}`" do
+      let(:fields_attributes) do
+        {'hoge' => {'fuga' => {'piyo' => last_child}}}
+      end
+
+      context "when last_child is String" do
+        let(:last_child) do
+          "String"
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo" => "String"}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+
+      context "when last_child has 'key' key" do
+        let(:last_child) do
+          {"key" => "BAR-1"}
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo.key" => "BAR-1"}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+
+      context "when last_child has 'id' key" do
+        let(:last_child) do
+          {"id" => "20"}
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo.id" => "20"}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+
+      context "when last_child has 'name' key" do
+        let(:last_child) do
+          {"name" => "Foo name"}
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo.name" => "Foo name"}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+
+      context "when last_child has another key except 'key', 'id', 'name'" do
+        let(:last_child) do
+          {"bar" => "piyo"}
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo" => "{\"bar\":\"piyo\"}"}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+
+      context "when last_child Hash Array" do
+        let(:last_child) do
+          [
+            {"key4" => "value1", "key5" => "value2"},
+            {"key6" => "value3", "key5" => "value4"},
+          ]
+        end
+
+        let(:exptected_record_from_fields) do
+          {"hoge.fuga.piyo" => '{"key4":["value1",null],"key5":["value2","value4"],"key6":[null,"value3"]}'}
+        end
+
+        it_behaves_like "return guessed record"
+      end
+    end
+
+    context "when fields_attributes is `{'hoge' => ['elem1', 'elem2', 'elem3'], 'fuga' => ['elem4', 'elem5', 'elem6']}`" do
+      let(:fields_attributes) do
+        {
+          'hoge' => ['elem1', 'elem2', 'elem3'],
+          'fuga' => ['elem4', 'elem5', 'elem6'],
+        }
+      end
+
+      let(:exptected_record_from_fields) do
+        {
+          "hoge" => '"elem1,elem2,elem3"',
+          "fuga" => '"elem4,elem5,elem6"',
+        }
+      end
+
+      it_behaves_like "return guessed record"
+    end
+
+    context "when fields_attributes is `{'hoge' => []}`" do
+      let(:fields_attributes) do
+        {'hoge' => []}
+      end
+
+      let(:exptected_record_from_fields) do
+        {"hoge" => '""'}
+      end
+
+      it_behaves_like "return guessed record"
+    end
+
+    context "when fields_attributes is `{'hoge' => { 'fuga' => [{'foo' => 'bar1'}, {'foo'=> 'bar2'}]}}`" do
+      let(:fields_attributes) do
+        {
+          'hoge' => {
+            'fuga' => [
+              {'foo' => 'bar1'}, {'foo'=> 'bar2'},
+            ]
+          }
+        }
+      end
+
+      let(:exptected_record_from_fields) do
+        {
+          "hoge.fuga.foo" => '"bar1,bar2"',
+        }
+      end
+
+      it_behaves_like "return guessed record"
+    end
+
+    context "when fields_attributes is `{'hoge' => { 'fuga' => ['elem1', 'elem2', 'elem3'], 'piyo' => ['elem4', 'elem5', 'elem6']}}`" do
+      let(:fields_attributes) do
+        {'hoge' => {'fuga' => ['elem1', 'elem2', 'elem3'], 'piyo' => ['elem4', 'elem5', 'elem6']}}
+      end
+
+      let(:exptected_record_from_fields) do
+        {
+          "hoge.fuga" => '"elem1,elem2,elem3"',
+          "hoge.piyo" => '"elem4,elem5,elem6"',
+        }
+      end
+
+      it_behaves_like "return guessed record"
     end
   end
 end

--- a/spec/embulk/input/jira/issue_spec.rb
+++ b/spec/embulk/input/jira/issue_spec.rb
@@ -351,7 +351,7 @@ describe Embulk::Input::Jira::Issue do
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'key1' => { 'key2' => [{'key3' => 'valu3-1'}, {'key3'=> 'value3-2'}]}}`" do
+    context "when fields_attributes is `{'key1' => { 'key2' => [{'key3' => 'value3-1'}, {'key3'=> 'value3-2'}]}}`" do
       let(:fields_attributes) do
         {
           'key1' => {

--- a/spec/embulk/input/jira/issue_spec.rb
+++ b/spec/embulk/input/jira/issue_spec.rb
@@ -73,73 +73,73 @@ describe Embulk::Input::Jira::Issue do
       end
     end
 
-    context "when fields_attributes is `{'hoge' => 'fuga'}` and attribute_name is 'hoge'" do
+    context "when fields_attributes is Hash" do
       let(:fields_attributes) do
-        {'hoge' => 'fuga'}
+        {'key' => 'value'}
       end
 
-      let(:attribute_name) { 'hoge' }
+      let(:attribute_name) { 'key' }
 
-      it "returns 'fuga'" do
-        expect(subject).to eq "fuga"
+      it "returns 'value'" do
+        expect(subject).to eq "FOO-1"
       end
     end
 
-    context "when fields_attributes is `{'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}`" do
+    context "when fields_attributes is `{'key1' => {'key2' => 'value2', 'key3' => 'value3'}}`" do
       let(:fields_attributes) do
-        {'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}
+        {'key1' => {'key2' => 'value2', 'key3' => 'value3'}}
       end
 
-      context "when attribute_name is 'hoge'" do
-        let(:attribute_name) { 'hoge' }
+      context "when attribute_name is 'key1'" do
+        let(:attribute_name) { 'key1' }
 
-        it "returns hoge's JSON" do
-          expect(subject).to eq({'fuga' => 'piyo', 'foo' => 'bar'}.to_json)
+        it "returns key1's JSON" do
+          expect(subject).to eq({'key2' => 'value2', 'key3' => 'value3'}.to_json)
         end
       end
 
-      context "when attribute_name is 'hoge.fuga'" do
-        let(:attribute_name) { 'hoge.fuga' }
+      context "when attribute_name is 'key1.key2'" do
+        let(:attribute_name) { 'key1.key2' }
 
-        it "returns 'piyo'" do
-          expect(subject).to eq 'piyo'
+        it "returns 'value2'" do
+          expect(subject).to eq 'value2'
         end
       end
     end
 
-    context "when fields_attributes is `{'hoge' => [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}]}`" do
+    context "when fields_attributes is `{'key1' => [{'key2' => 'value2-1'}, {'key2' => 'value2-2'}]}`" do
       let(:fields_attributes) do
-        {'hoge' => [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}]}
+        {'key1' => [{'key2' => 'value2-1'}, {'key2' => 'value2-2'}]}
       end
 
-      context "when attribute_name is 'hoge'" do
-        let(:attribute_name) { 'hoge' }
+      context "when attribute_name is 'key1'" do
+        let(:attribute_name) { 'key1' }
 
         it "returns JSON array" do
-          expect(subject).to eq [{'bar' => 'piyo1'}, {'bar' => 'piyo2'}].to_json
+          expect(subject).to eq [{'key2' => 'value2-1'}, {'key2' => 'value2-2'}].to_json
         end
       end
 
-      context "when attribute_name is 'hoge.bar'" do
-        let(:attribute_name) { 'hoge.bar' }
+      context "when attribute_name is 'key1.key2'" do
+        let(:attribute_name) { 'key1.key2' }
 
-        it "returns CSV values assigned by 'bar' key" do
-          expect(subject).to eq 'piyo1,piyo2'
+        it "returns CSV values assigned by 'key2' key" do
+          expect(subject).to eq 'value2-1,value2-2'
         end
       end
     end
 
-    context "when fields_attributes is `{'hoge' => ['elem1', 'elem2', 'elem3']}` and attribute_name is 'hoge'" do
+    context "when fields_attributes is `{'key1' => ['element1', 'element2', 'element3']}`" do
       let(:fields_attributes) do
         {
-          'hoge' => ['elem1', 'elem2', 'elem3'],
+          'key1' => ['element1', 'element2', 'element3'],
         }
       end
 
-      let(:attribute_name) { 'hoge' }
+      let(:attribute_name) { 'key1' }
 
-      it "returns CSV values assigned by 'hoge'" do
-        expect(subject).to eq 'elem1,elem2,elem3'
+      it "returns CSV values assigned by 'key1'" do
+        expect(subject).to eq 'element1,element2,element3'
       end
     end
   end
@@ -166,36 +166,41 @@ describe Embulk::Input::Jira::Issue do
       }.merge(exptected_record_from_fields)
     end
 
-    context "when fields_attributes is `{'hoge' => 'fuga'}`" do
+    context "when fields_attributes is `{'key' => 'value'}`" do
       let(:fields_attributes) do
-        {'hoge' => 'fuga'}
+        {'key' => 'value'}
       end
 
       let(:exptected_record_from_fields) do
-        {'hoge' => 'fuga'}
+        {'key' => 'value'}
       end
 
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}`" do
+    context "when fields_attributes is `{'key1' => {'key2' => 'value2', 'key3' => 'value3'}}`" do
       let(:fields_attributes) do
-        {'hoge' => {'fuga' => 'piyo', 'foo' => 'bar'}}
+        {
+          'key1' => {
+            'key2' => 'value2',
+            'key3' => 'value3',
+          }
+        }
       end
 
       let(:exptected_record_from_fields) do
         {
-          "hoge.fuga" => "piyo",
-          "hoge.foo" => "bar"
+          "key1.key2" => "value2",
+          "key1.key3" => "value3"
         }
       end
 
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'hoge' => {'fuga' => {'piyo' => last_child}}}`" do
+    context "when fields_attributes is `{'key1' => {'key2' => {'key3' => last_child}}}`" do
       let(:fields_attributes) do
-        {'hoge' => {'fuga' => {'piyo' => last_child}}}
+        {'key1' => {'key2' => {'key3' => last_child}}}
       end
 
       context "when last_child is String" do
@@ -204,7 +209,7 @@ describe Embulk::Input::Jira::Issue do
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo" => "String"}
+          {"key1.key2.key3" => "String"}
         end
 
         it_behaves_like "return guessed record"
@@ -216,7 +221,7 @@ describe Embulk::Input::Jira::Issue do
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo.key" => "BAR-1"}
+          {"key1.key2.key3.key" => "BAR-1"}
         end
 
         it_behaves_like "return guessed record"
@@ -228,7 +233,7 @@ describe Embulk::Input::Jira::Issue do
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo.id" => "20"}
+          {"key1.key2.key3.id" => "20"}
         end
 
         it_behaves_like "return guessed record"
@@ -240,7 +245,7 @@ describe Embulk::Input::Jira::Issue do
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo.name" => "Foo name"}
+          {"key1.key2.key3.name" => "Foo name"}
         end
 
         it_behaves_like "return guessed record"
@@ -248,11 +253,11 @@ describe Embulk::Input::Jira::Issue do
 
       context "when last_child has another key except 'key', 'id', 'name'" do
         let(:last_child) do
-          {"bar" => "piyo"}
+          {"customfield_0001" => "value0001"}
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo" => "{\"bar\":\"piyo\"}"}
+          {"key1.key2.key3" => "{\"customfield_0001\":\"value0001\"}"}
         end
 
         it_behaves_like "return guessed record"
@@ -261,55 +266,55 @@ describe Embulk::Input::Jira::Issue do
       context "when last_child Hash Array" do
         let(:last_child) do
           [
-            {"key4" => "value1", "key5" => "value2"},
-            {"key6" => "value3", "key5" => "value4"},
+            {"key4" => "value4", "key5" => "value5-1"},
+            {"key6" => "value6", "key5" => "value5-2"},
           ]
         end
 
         let(:exptected_record_from_fields) do
-          {"hoge.fuga.piyo" => '{"key4":["value1",null],"key5":["value2","value4"],"key6":[null,"value3"]}'}
+          {"key1.key2.key3" => '{"key4":["value4",null],"key5":["value5-1","value5-2"],"key6":[null,"value6"]}'}
         end
 
         it_behaves_like "return guessed record"
       end
     end
 
-    context "when fields_attributes is `{'hoge' => ['elem1', 'elem2', 'elem3'], 'fuga' => ['elem4', 'elem5', 'elem6']}`" do
+    context "when fields_attributes is `{'key1' => ['element1-1', 'element1-2', 'element1-3'], 'key2' => ['element2-1', 'element2-2', 'element2-3']}`" do
       let(:fields_attributes) do
         {
-          'hoge' => ['elem1', 'elem2', 'elem3'],
-          'fuga' => ['elem4', 'elem5', 'elem6'],
+          'key1' => ['element1-1', 'element1-2', 'element1-3'],
+          'key2' => ['element2-1', 'element2-2', 'element2-3'],
         }
       end
 
       let(:exptected_record_from_fields) do
         {
-          "hoge" => '"elem1,elem2,elem3"',
-          "fuga" => '"elem4,elem5,elem6"',
+          'key1' => '"element1-1,element1-2,element1-3"',
+          'key2' => '"element2-1,element2-2,element2-3"',
         }
       end
 
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'hoge' => []}`" do
+    context "when fields_attributes is `{'key' => []}`" do
       let(:fields_attributes) do
-        {'hoge' => []}
+        {'key' => []}
       end
 
       let(:exptected_record_from_fields) do
-        {"hoge" => '""'}
+        {"key" => '""'}
       end
 
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'hoge' => { 'fuga' => [{'foo' => 'bar1'}, {'foo'=> 'bar2'}]}}`" do
+    context "when fields_attributes is `{'key1' => { 'key2' => [{'key3' => 'valu3-1'}, {'key3'=> 'value3-2'}]}}`" do
       let(:fields_attributes) do
         {
-          'hoge' => {
-            'fuga' => [
-              {'foo' => 'bar1'}, {'foo'=> 'bar2'},
+          'key1' => {
+            'key2' => [
+              {'key3' => 'value3-1'}, {'key3'=> 'value3-2'},
             ]
           }
         }
@@ -317,22 +322,27 @@ describe Embulk::Input::Jira::Issue do
 
       let(:exptected_record_from_fields) do
         {
-          "hoge.fuga.foo" => '"bar1,bar2"',
+          "key1.key2.key3" => '"value3-1,value3-2"',
         }
       end
 
       it_behaves_like "return guessed record"
     end
 
-    context "when fields_attributes is `{'hoge' => { 'fuga' => ['elem1', 'elem2', 'elem3'], 'piyo' => ['elem4', 'elem5', 'elem6']}}`" do
+    context "when fields_attributes is `{'key1' => { 'key2' => ['element2-1', 'element2-2', 'element2-3'], 'key3' => ['element3-1', 'element3-2', 'element3-3']}}`" do
       let(:fields_attributes) do
-        {'hoge' => {'fuga' => ['elem1', 'elem2', 'elem3'], 'piyo' => ['elem4', 'elem5', 'elem6']}}
+        {
+          'key1' => {
+            'key2' => ['element2-1', 'element2-2', 'element2-3'],
+            'key3' => ['element3-1', 'element3-2', 'element3-3']
+          }
+        }
       end
 
       let(:exptected_record_from_fields) do
         {
-          "hoge.fuga" => '"elem1,elem2,elem3"',
-          "hoge.piyo" => '"elem4,elem5,elem6"',
+          "key1.key2" => '"element2-1,element2-2,element2-3"',
+          "key1.key3" => '"element3-1,element3-2,element3-3"',
         }
       end
 

--- a/spec/embulk/input/jira/issue_spec.rb
+++ b/spec/embulk/input/jira/issue_spec.rb
@@ -73,6 +73,26 @@ describe Embulk::Input::Jira::Issue do
       end
     end
 
+    context "when fields_attributes is empty Hash" do
+      let(:fields_attributes) { {} }
+
+      let(:attribute_name) { 'key1' }
+
+      it "returns nil" do
+        expect(subject).to eq nil
+      end
+    end
+
+    context "when fields_attributes is empty Hash including Array" do
+      let(:fields_attributes) { { 'key1' => [] } }
+
+      let(:attribute_name) { 'key1' }
+
+      it "returns empty Array" do
+        expect(subject).to eq []
+      end
+    end
+
     context "when fields_attributes is Hash" do
       let(:fields_attributes) do
         {'key' => 'value'}
@@ -116,7 +136,7 @@ describe Embulk::Input::Jira::Issue do
         let(:attribute_name) { 'key1' }
 
         it "returns JSON array" do
-          expect(subject).to eq [{'key2' => 'value2-1'}, {'key2' => 'value2-2'}].to_json
+          expect(subject).to eq '{"key2":"value2-1"},{"key2":"value2-2"}'
         end
       end
 
@@ -125,6 +145,28 @@ describe Embulk::Input::Jira::Issue do
 
         it "returns CSV values assigned by 'key2' key" do
           expect(subject).to eq 'value2-1,value2-2'
+        end
+      end
+    end
+
+    context "when fields_attributes is `{'key1' => [{'key2' => 'value2-1'}, nil]}`" do
+      let(:fields_attributes) do
+        {'key1' => [{'key2' => 'value2-1'}, nil]}
+      end
+
+      context "when attribute_name is 'key1'" do
+        let(:attribute_name) { 'key1' }
+
+        it "returns CSV value including null" do
+          expect(subject).to eq '{"key2":"value2-1"},null'
+        end
+      end
+
+      context "when attribute_name is 'key1.key2'" do
+        let(:attribute_name) { 'key1.key2' }
+
+        it "returns JSON array including null" do
+          expect(subject).to eq 'value2-1,null'
         end
       end
     end

--- a/spec/embulk/input/jira_input_plugin_spec.rb
+++ b/spec/embulk/input/jira_input_plugin_spec.rb
@@ -116,12 +116,12 @@ describe Embulk::Input::JiraInputPlugin do
     let(:guessed_config) do
       {
         "columns" => [
+          {name: "comment.comments", type: :string},
+          {name: "comment.total", type: :long},
           {name: "id", type: :long},
           {name: "key", type: :string},
-          {name: "project.name", type: :string},
           {name: "project.key", type: :string},
-          {name: "comment.total", type: :long},
-          {name: "comment.comments", type: :string},
+          {name: "project.name", type: :string},
         ]
       }
     end

--- a/spec/embulk/input/jira_input_plugin_spec.rb
+++ b/spec/embulk/input/jira_input_plugin_spec.rb
@@ -119,7 +119,9 @@ describe Embulk::Input::JiraInputPlugin do
           {name: "id", type: :long},
           {name: "key", type: :string},
           {name: "project.name", type: :string},
-          {name: "comment", type: :string}
+          {name: "project.key", type: :string},
+          {name: "comment.total", type: :long},
+          {name: "comment.comments", type: :string},
         ]
       }
     end


### PR DESCRIPTION
Before, `embulk guess` output `field_name.{key or id}` as key but if this value is JSON, `embulk preview/run` with guessed config output JSON it isn't readable:(

So, I implement `guess` command looks 2 nested JSON and put config, and `preview/run` command understand it.

Futhermore, I implement guessed columns are sorted by alphabetically for readable config.

(edited)

For example, this PR changes guessed schema for `comment`.

Before:
`- {name: comment, type: string}`
After:

```
  - {name: comment.comments.author.key, type: string}
  - {name: comment.comments.author.name, type: string}
  - {name: comment.comments.body, type: string}
  - {name: comment.comments.created, type: string}
  - {name: comment.comments.id, type: string}
  - {name: comment.comments.self, type: string}
  - {name: comment.comments.updateAuthor.key, type: string}
  - {name: comment.comments.updateAuthor.name, type: string}
  - {name: comment.comments.updated, type: string}
  - {name: comment.maxResults, type: long}
  - {name: comment.startAt, type: long}
  - {name: comment.total, type: long}
```

(BTW, Records used for guess change schema result, many records make more proper schema, but more slowly)
