### PR TITLE
Follow embulk 0 6 12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org/'
 
 # NOTE: Bundler.require(:runtime, :development) in spec_helper that require all dependencies
 #       but require 'embulk' will be failed. so separate it from gemspec ecosystem
-gem 'embulk', ">= 0.6", "< 1.0"
+gem 'embulk', ">= 0.6.12", "< 1.0"
 gem "codeclimate-test-reporter", require: nil
 
 gemspec

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ embulk-input-jira is the Embulk input plugin for [JIRA](https://www.atlassian.co
 
 ## Overview
 
+Required Embulk version >= 0.6.12
+
 * **Plugin type**: input
 * **Resume supported**: no
 * **Cleanup supported**: no

--- a/lib/embulk/input/jira_input_plugin.rb
+++ b/lib/embulk/input/jira_input_plugin.rb
@@ -117,14 +117,7 @@ module Embulk
       end
 
       def self.logger
-        @logger ||=
-          begin
-            logger = Logger.new($stdout)
-            logger.formatter = proc do |severity, datetime, progname, msg|
-              "#{datetime.strftime("%Y-%m-%d %H:%M:%S.%L %z")} [#{severity}] #{msg}\n"
-            end
-            logger
-          end
+        Embulk.logger
       end
 
       def logger

--- a/lib/embulk/input/jira_input_plugin.rb
+++ b/lib/embulk/input/jira_input_plugin.rb
@@ -86,9 +86,9 @@ module Embulk
       end
 
       def run
-        # NOTE: This is workaround for "org.embulk.spi.Exec.isPreview"
         # TODO: Extract process for preview command to method
-        if org.embulk.spi.Exec.session().isPreview()
+        # http://www.embulk.org/docs/release/release-0.6.12.html
+        if org.embulk.spi.Exec.isPreview()
           options = {max_results: PREVIEW_RECORDS_COUNT}
           total_count = PREVIEW_RECORDS_COUNT
           last_page = 1

--- a/spec/embulk/input/jira_input_plugin_spec.rb
+++ b/spec/embulk/input/jira_input_plugin_spec.rb
@@ -243,7 +243,7 @@ describe Embulk::Input::JiraInputPlugin do
 
     subject { logger }
 
-    it { is_expected.to be_a(Logger) }
+    it { is_expected.to be_a(Embulk::Logger) }
   end
 
   describe "#logger" do
@@ -252,6 +252,6 @@ describe Embulk::Input::JiraInputPlugin do
 
     subject { logger }
 
-    it { is_expected.to be_a(Logger) }
+    it { is_expected.to be_a(Embulk::Logger) }
   end
 end

--- a/spec/embulk/input/jira_input_plugin_spec.rb
+++ b/spec/embulk/input/jira_input_plugin_spec.rb
@@ -207,7 +207,7 @@ describe Embulk::Input::JiraInputPlugin do
     let(:commit_report) { {} }
 
     before do
-      allow(org.embulk.spi.Exec).to receive_message_chain(:session, :isPreview).and_return(false)
+      allow(org.embulk.spi.Exec).to receive(:isPreview).and_return(false)
 
       # TODO: create stubs without each `it` expected
       allow(Embulk::Input::Jira::Api).to receive(:setup).and_return(jira_api)

--- a/spec/embulk_spec.rb
+++ b/spec/embulk_spec.rb
@@ -11,7 +11,7 @@ in:
     before do
       config_file.puts config
       config_file.close
-      allow(org.embulk.spi.Exec).to receive_message_chain(:session, :isPreview).and_return(true)
+      allow(org.embulk.spi.Exec).to receive(:isPreview).and_return(true)
     end
 
     subject {


### PR DESCRIPTION
Embulk 0.6.12 has own logger, so plugins should use it instead of their one.
