### PR TITLE
Faster fetching with parallel API request

### DIFF
--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'jiralicious', ['~> 0.5.0']
+  spec.add_dependency 'parallel', ['~> 1.6.0']
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']
   spec.add_development_dependency 'rspec', "~> 3.2.0"

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -19,8 +19,8 @@ module Embulk
 
         def search_issues(jql, options={})
           timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS) do
-            issues = search(jql, options).issues_raw
-            Parallel.map(issues, in_threads: PARALLEL_THREAD_COUNT) do |issue_raw|
+            issues_raw = search(jql, options).issues_raw
+            Parallel.map(issues_raw, in_threads: PARALLEL_THREAD_COUNT) do |issue_raw|
               # https://github.com/dorack/jiralicious/blob/v0.4.0/lib/jiralicious/search_result.rb#L32-34
               issue = Jiralicious::Issue.find(issue_raw["key"])
               JiraApi::Issue.new(issue)

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -48,7 +48,7 @@ describe Embulk::Input::JiraApi::Client do
             "summary" => "issue summary",
             "project" =>
             {
-              "key" => "FOO"
+              "key" => "FO1"
             }
           }
         },
@@ -60,7 +60,7 @@ describe Embulk::Input::JiraApi::Client do
             "summary" => "jira issue",
             "project" =>
             {
-              "key" => "FOO"
+              "key" => "FO2"
             }
           }
         }
@@ -70,7 +70,8 @@ describe Embulk::Input::JiraApi::Client do
     subject { Embulk::Input::JiraApi::Client.new.search_issues(jql) }
 
     it do
-      allow(Jiralicious).to receive_message_chain(:search, :issues).and_return(results)
+      allow(Jiralicious).to receive_message_chain(:search, :issues_raw).and_return(results)
+      allow(Jiralicious::Issue).to receive(:find).and_return(results.first)
 
       expect(subject).to be_kind_of Array
       expect(subject.map(&:class)).to match_array [Embulk::Input::JiraApi::Issue, Embulk::Input::JiraApi::Issue]


### PR DESCRIPTION
`Jiralicious.search` invokes HTTP request 3 times per issue, if you get 50 issues from search API, you will finally do 150 requests to JIRA API.
This PR solves that problem by parallelize HTTP requests with [parallel gem](https://github.com/grosser/parallel).
# Before

```
$ /usr/bin/time bundle exec embulk preview -L ./ guessed.yml > /dev/null
      678.17 real        41.11 user         3.16 sys
```
# After (with 50 threads)

```
$ /usr/bin/time bundle exec embulk preview -L ./ guessed.yml > /dev/null
       30.08 real        28.97 user         1.71 sys
```
