### PR TITLE
Add a logic to check credentials before searching issues

### DIFF
--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -63,7 +63,7 @@ module Embulk
         retryer = retryer(retry_limit, retry_initial_wait_sec)
 
         # Get credential before going to search issue
-        jira.get_user_credential(username)
+        jira.check_user_credential(username)
 
         # TODO: we use 0..10 issues to guess config?
         records = retryer.with_retry do
@@ -97,7 +97,7 @@ module Embulk
       def run
         return preview if preview?
 
-        @jira.get_user_credential(task[:username])
+        @jira.check_user_credential(task[:username])
         options = {}
         total_count = @jira.total_count(@jql)
         last_page = (total_count.to_f / PER_PAGE).ceil
@@ -141,7 +141,7 @@ module Embulk
       private
 
       def preview
-        @jira.get_user_credential(task[:username])
+        @jira.check_user_credential(task[:username])
 
         logger.debug "For preview mode, JIRA input plugin fetches records at most #{PREVIEW_RECORDS_COUNT}"
         @jira.search_issues(@jql, max_results: PREVIEW_RECORDS_COUNT).each do |issue|

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -40,7 +40,7 @@ module Embulk
           search(jql, max_results: 1).num_results
         end
 
-        def get_user_credential(username)
+        def check_user_credential(username)
           Jiralicious::Issue.find(username)
         rescue Jiralicious::JqlError, Jiralicious::AuthenticationError, Jiralicious::NotLoggedIn, Jiralicious::InvalidLogin => e
           raise Embulk::ConfigError.new(e.message)

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -40,6 +40,19 @@ module Embulk
           search(jql, max_results: 1).num_results
         end
 
+        def get_user_credential(username)
+          Jiralicious::Issue.find(username)
+        rescue Jiralicious::JqlError, Jiralicious::AuthenticationError, Jiralicious::NotLoggedIn, Jiralicious::InvalidLogin => e
+          raise Embulk::ConfigError.new(e.message)
+        rescue ::SocketError => e
+          # wrong `uri` option given
+          raise Embulk::ConfigError.new(e.message)
+        rescue MultiJson::ParseError => e
+          html = e.message
+          title = html[%r|<title>(.*?)</title>|, 1] #=> e.g. "Unauthorized (401)"
+          raise ConfigError.new("Can not authorize with your credential.") if title == 'Unauthorized (401)'
+        end
+
         private
 
         def timeout_and_retry(wait, retry_times = DEFAULT_SEARCH_RETRY_TIMES, &block)
@@ -61,13 +74,12 @@ module Embulk
             title = html[%r|<title>(.*?)</title>|, 1] #=> e.g. "Unauthorized (401)"
             if title
               # (a)
-              Embulk.logger.warn "JIRA returns HTML: #{html}"
               case title
               when "Atlassian Cloud Notifications - Page Unavailable"
                 # a.k.a. HTTP 503
                 raise title
               when "Unauthorized (401)"
-                Embulk.logger.warn "JIRA returns error: #{title}"
+                Embulk.logger.warn "JIRA returns error: #{title}. Will go to retry"
                 count += 1
                 retry
               end

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -131,7 +131,7 @@ describe Embulk::Input::Jira do
     end
 
     before do
-      allow(jira_api).to receive(:get_user_credential).with(username).and_return(username)
+      allow(jira_api).to receive(:check_user_credential).with(username).and_return(username)
       allow(jira_api).to receive(:search_issues).with(jql, max_results: described_class::GUESS_RECORDS_COUNT).and_return(jira_issues)
 
       allow(config).to receive(:param).with(:username, :string).and_return(username)
@@ -219,7 +219,7 @@ describe Embulk::Input::Jira do
 
       # TODO: create stubs without each `it` expected
       allow(Embulk::Input::JiraApi::Client).to receive(:setup).and_return(jira_api)
-      allow(jira_api).to receive(:get_user_credential).and_return(username)
+      allow(jira_api).to receive(:check_user_credential).and_return(username)
 
       0.step(total_count, max_result) do |start_at|
         issues = jira_issues[start_at..(start_at + max_result - 1)]
@@ -285,7 +285,7 @@ describe Embulk::Input::Jira do
       allow(Embulk::Input::JiraApi::Client).to receive(:setup).and_return(jira_api)
       allow(plugin).to receive(:logger).and_return(::Logger.new(File::NULL))
       allow(plugin).to receive(:preview?).and_return(true)
-      allow(jira_api).to receive(:get_user_credential).and_return(username)
+      allow(jira_api).to receive(:check_user_credential).and_return(username)
       allow(jira_api).to receive(:search_issues).and_return(jira_issues)
       allow(page_builder).to receive(:add)
       allow(page_builder).to receive(:finish)

--- a/spec/embulk/input/jira_spec.rb
+++ b/spec/embulk/input/jira_spec.rb
@@ -131,6 +131,7 @@ describe Embulk::Input::Jira do
     end
 
     before do
+      allow(jira_api).to receive(:get_user_credential).with(username).and_return(username)
       allow(jira_api).to receive(:search_issues).with(jql, max_results: described_class::GUESS_RECORDS_COUNT).and_return(jira_issues)
 
       allow(config).to receive(:param).with(:username, :string).and_return(username)
@@ -211,12 +212,14 @@ describe Embulk::Input::Jira do
     end
 
     let(:commit_report) { {} }
+    let(:username) { "jira-user" }
 
     before do
       allow(jira_api).to receive(:preview?).and_return(false)
 
       # TODO: create stubs without each `it` expected
       allow(Embulk::Input::JiraApi::Client).to receive(:setup).and_return(jira_api)
+      allow(jira_api).to receive(:get_user_credential).and_return(username)
 
       0.step(total_count, max_result) do |start_at|
         issues = jira_issues[start_at..(start_at + max_result - 1)]
@@ -256,6 +259,7 @@ describe Embulk::Input::Jira do
     let(:page_builder) { double("page_builder") }
     let(:jira_api) { Embulk::Input::JiraApi::Client.new }
     let(:jira_issues) { [Embulk::Input::JiraApi::Issue.new(attributes)] }
+    let(:username) { "jira-user" }
     let(:attributes) do
       {
         "id" => "100",
@@ -281,6 +285,7 @@ describe Embulk::Input::Jira do
       allow(Embulk::Input::JiraApi::Client).to receive(:setup).and_return(jira_api)
       allow(plugin).to receive(:logger).and_return(::Logger.new(File::NULL))
       allow(plugin).to receive(:preview?).and_return(true)
+      allow(jira_api).to receive(:get_user_credential).and_return(username)
       allow(jira_api).to receive(:search_issues).and_return(jira_issues)
       allow(page_builder).to receive(:add)
       allow(page_builder).to receive(:finish)


### PR DESCRIPTION
## CHANGES
- With wrong credentials, the block of `timeout_and_retry` will fall in loop. This PR will fix it by adding a logic to check credentials and throw the EmbulkConfig before searching issues