### PR TITLE
Fix infinitive 401 errors and dynamically adjust parallel threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.2.5 - 2018-11-20
+## 0.2.5 - 2018-11-27
 
-* [fixed] Automatically turning number of concurrent threads to find issues [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
+* [fixed] Fix infinitive 401 errors and dynamically adjust parallel threads [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
 
 ## 0.2.4 - 2017-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.5 - 2018-11-20
+
+* [fixed] Reduce the number of concurrent threads to search issues to maximum = 5 [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
+
 ## 0.2.4 - 2017-11-17
 
 * [fixed] Fixed checking credentials by `Jiralicious User` [#51](https://github.com/treasure-data/embulk-input-jira/pull/51)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.5 - 2018-11-20
 
-* [fixed] Reduce the number of concurrent threads to search issues to maximum = 5 [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
+* [fixed] Automatically turning number of concurrent threads to search issues [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
 
 ## 0.2.4 - 2017-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.2.5 - 2018-11-20
 
-* [fixed] Automatically turning number of concurrent threads to search issues [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
+* [fixed] Automatically turning number of concurrent threads to find issues [#52](https://github.com/treasure-data/embulk-input-jira/pull/52)
 
 ## 0.2.4 - 2017-11-17
 

--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-jira"
-  spec.version       = "0.2.4"
+  spec.version       = "0.2.5"
   spec.authors       = ["uu59", "yoshihara"]
   spec.summary       = "Jira input plugin for Embulk"
   spec.description   = "Loads records from Jira."

--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-jira"
-  spec.version       = "0.2.5.alpha.03"
+  spec.version       = "0.2.5"
   spec.authors       = ["uu59", "yoshihara"]
   spec.summary       = "Jira input plugin for Embulk"
   spec.description   = "Loads records from Jira."

--- a/embulk-input-jira.gemspec
+++ b/embulk-input-jira.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-jira"
-  spec.version       = "0.2.5"
+  spec.version       = "0.2.5.alpha.03"
   spec.authors       = ["uu59", "yoshihara"]
   spec.summary       = "Jira input plugin for Embulk"
   spec.description   = "Loads records from Jira."
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'jiralicious', ['~> 0.5.0']
   spec.add_dependency 'parallel', ['~> 1.6.0']
+  spec.add_dependency 'ruby-limiter', ['~> 1.0']
   spec.add_dependency 'perfect_retry', ['~> 0.3']
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['< 11.0']

--- a/lib/embulk/input/jira.rb
+++ b/lib/embulk/input/jira.rb
@@ -103,7 +103,7 @@ module Embulk
         last_page = (total_count.to_f / PER_PAGE).ceil
 
         0.step(total_count, PER_PAGE).with_index(1) do |start_at, page|
-          logger.debug "Fetching #{page} / #{last_page} page"
+          logger.info "Fetching #{page} / #{last_page} page"
           @retryer.with_retry do
             @jira.search_issues(@jql, options.merge(start_at: start_at)).each do |issue|
               values = @attributes.map do |(attribute_name, type)|

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -23,7 +23,6 @@ module Embulk
 
         def search_issues(jql, options={})
           parallel_threads = MAX_CONCURRENT_REQUESTS
-          # Maximum time to wait is (300 * maximum_number_of_request / parallel_threads)
           timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS * MAX_CONCURRENT_REQUESTS ) do
             issues_raw = search(jql, options).issues_raw
             # TODO: below code has race-conditon.
@@ -35,7 +34,6 @@ module Embulk
             while issues_raw.length > 0 && search_issue_count <= DEFAULT_SEARCH_RETRY_TIMES do
               search_results = Parallel.map(issues_raw, in_threads: parallel_threads) do |issue_raw|
                 # https://github.com/dorack/jiralicious/blob/v0.4.0/lib/jiralicious/search_result.rb#L32-34
-                
                 begin
                   issue = Jiralicious::Issue.find(issue_raw["key"])
                   {

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -7,9 +7,7 @@ module Embulk
   module Input
     module JiraApi
       class Client
-        # According to this discussion https://community.developer.atlassian.com/t/are-there-rate-limits-for-jira-cloud-apis/4317/4
-        # So decided to choose the lower bound for safety
-        MAX_CONCURRENT_REQUESTS = 5
+        MAX_CONCURRENT_REQUESTS = 50
         # Normal http request timeout is 300s
         SEARCH_ISSUES_TIMEOUT_SECONDS = 300
         DEFAULT_SEARCH_RETRY_TIMES = 10
@@ -19,18 +17,70 @@ module Embulk
           new
         end
 
+        def find_at_key(array, key)
+          
+        end
+
         def search_issues(jql, options={})
-          number_of_processors = Parallel.processor_count
-          parallel_threads = (number_of_processors - 1) <=1 ? 2 : (number_of_processors - 1) > MAX_CONCURRENT_REQUESTS ? MAX_CONCURRENT_REQUESTS : (number_of_processors - 1)
+          parallel_threads = MAX_CONCURRENT_REQUESTS
           # Maximum time to wait is (300 * maximum_number_of_request / parallel_threads)
-          timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS * 50 / parallel_threads) do
+          timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS * MAX_CONCURRENT_REQUESTS ) do
             issues_raw = search(jql, options).issues_raw
             # TODO: below code has race-conditon.
-            Parallel.map(issues_raw, in_threads: parallel_threads) do |issue_raw|
-              # https://github.com/dorack/jiralicious/blob/v0.4.0/lib/jiralicious/search_result.rb#L32-34
-              issue = Jiralicious::Issue.find(issue_raw["key"])
-              JiraApi::Issue.new(issue)
+            success_items = []
+            fail_items = []
+            errors = []
+            search_issue_count = 0
+            
+            while issues_raw.length > 0 && search_issue_count <= DEFAULT_SEARCH_RETRY_TIMES do
+              search_results = Parallel.map(issues_raw, in_threads: parallel_threads) do |issue_raw|
+                # https://github.com/dorack/jiralicious/blob/v0.4.0/lib/jiralicious/search_result.rb#L32-34
+                
+                begin
+                  issue = Jiralicious::Issue.find(issue_raw["key"])
+                  {
+                    :error => nil,
+                    :result => JiraApi::Issue.new(issue)
+                  }
+                rescue MultiJson::ParseError => e
+                  html = e.message
+                  title = html[%r|<title>(.*?)</title>|, 1] #=> e.g. "Unauthorized (401)"
+                  raise title if title != "Unauthorized (401)"
+                  {
+                    :error => e,
+                    :issue_raw => issue_raw,
+                    :result => nil
+                  }
+                end
+              end
+              search_issue_count += 1
+              for issue_result in search_results do
+                if !issue_result[:error].nil? 
+                  fail_items.push(issue_result[:issue_raw])
+                  errors.push(issue_result[:error])
+                else
+                  success_items.push(issue_result[:result])
+                end
+              end
+              raise errors[0] if search_issue_count > DEFAULT_SEARCH_RETRY_TIMES && errors.length > 0
+              # Turning number of parallel threads based on number of success and failure items
+              # Minumum is 2
+              number_of_success_item = issues_raw.length - fail_items.length
+              new_parallel_threads = 0;
+              if number_of_success_item < 2
+                new_parallel_threads = 2
+              elsif number_of_success_item > fail_items.length
+                new_parallel_threads = fail_items.length
+              else
+                new_parallel_threads = number_of_success_item
+              end
+              # Add limit for new parallel_threads to not greater than 2 times the current parallel threads
+              parallel_threads = (new_parallel_threads > parallel_threads * 2) ? parallel_threads * 2 : new_parallel_threads
+              issues_raw = fail_items
+              fail_items = []
+              errors = []
             end
+            success_items
           end
         end
 
@@ -60,7 +110,7 @@ module Embulk
         private
 
         def timeout_and_retry(wait, retry_times = DEFAULT_SEARCH_RETRY_TIMES, &block)
-          count = 1
+          count = 0
           begin
             Timeout.timeout(wait) do
               yield
@@ -76,26 +126,17 @@ module Embulk
             # And (b) `search_issues` method has race-condition bug. If it occurred, MultiJson::ParseError raised too.
             html = e.message
             title = html[%r|<title>(.*?)</title>|, 1] #=> e.g. "Unauthorized (401)"
-            if title
-              # (a)
-              case title
-              when "Atlassian Cloud Notifications - Page Unavailable"
-                # a.k.a. HTTP 503
-                raise title
-              when "Unauthorized (401)"
-                Embulk.logger.warn "JIRA returns error: #{title}. Will go to retry"
-                count += 1
-                retry
-              end
-            else
-              # (b)
-              count += 1
-              retry
-            end
+            raise title if title == "Atlassian Cloud Notifications - Page Unavailable"
+            count += 1
+            raise title.nil? ? "Unknown Error" : title if count > retry_times
+            Embulk.logger.warn "JIRA returns error: #{title}."
+            sleep count
+            retry
           rescue Timeout::Error => e
             count += 1
-            sleep count # retry after some seconds for JIRA API perhaps under the overload
             raise e if count > retry_times
+            Embulk.logger.warn "Time out error."
+            sleep count # retry after some seconds for JIRA API perhaps under the overload
             retry
           end
         end

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -24,7 +24,6 @@ module Embulk
         end
 
         def search_issues(jql, options={})
-          Embulk.logger.warn "Process count #{Parallel.processor_count}"
           parallel_threads = MAX_CONCURRENT_REQUESTS
           timeout_and_retry(SEARCH_ISSUES_TIMEOUT_SECONDS * MAX_CONCURRENT_REQUESTS ) do
             issues_raw = search(jql, options).issues_raw
@@ -67,12 +66,12 @@ module Embulk
               raise errors[0] if search_issue_count > DEFAULT_SEARCH_RETRY_TIMES && errors.length > 0
               # Turning number of parallel threads based on number of success and failure items
               # Minumum is 2
-              Embulk.logger.info "All : #{issues_raw.length}"
-              Embulk.logger.info "Error : #{fail_items.length}"
-              Embulk.logger.info "Parallel : #{parallel_threads}"
+              # Embulk.logger.info "All : #{issues_raw.length}"
+              # Embulk.logger.info "Error : #{fail_items.length}"
+              # Embulk.logger.info "Parallel : #{parallel_threads}"
               
               parallel_threads = calculate_parallel_threads(parallel_threads, issues_raw.length, fail_items.length, search_issue_count)
-              Embulk.logger.info "New Parallel : #{parallel_threads}"
+              # Embulk.logger.info "New Parallel : #{parallel_threads}"
               sleep search_issue_count
               issues_raw = fail_items
               fail_items = []
@@ -106,7 +105,7 @@ module Embulk
         end
 
         def calculate_parallel_threads(current_parallel, all_items, fail_items, times)
-          Embulk.logger.warn "Tuning times : #{times}"
+          # Embulk.logger.warn "Tuning times : #{times}"
           success_items = all_items - fail_items
           return MIN_CONCURRENT_REQUESTS if times > DEFAULT_SEARCH_RETRY_TIMES/2 || success_items < MIN_CONCURRENT_REQUESTS
           return [fail_items, success_items, current_parallel*2].min

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -122,7 +122,7 @@ module Embulk
             raise title if title == "Atlassian Cloud Notifications - Page Unavailable"
             count += 1
             raise title.nil? ? "Unknown Error" : title if count > retry_times
-            Embulk.logger.warn "JIRA returns error: #{title}."
+            Embulk.logger.warn "JIRA returns error: #{title == 'Unauthorized (401)' ? title + " due to overloading API requests. Retrying on failed items only" : title}."
             sleep count
             retry
           rescue Timeout::Error => e

--- a/lib/embulk/input/jira_api/client.rb
+++ b/lib/embulk/input/jira_api/client.rb
@@ -36,7 +36,7 @@ module Embulk
             @rate_limiter = Limiter::RateQueue.new(rate_limit, interval: 2)
             error_object = nil
             while issues_raw.length > 0 && retry_count <= DEFAULT_SEARCH_RETRY_TIMES do
-              search_results = Parallel.each(issues_raw, in_threads: rate_limit) do |issue_raw|
+              Parallel.each(issues_raw, in_threads: rate_limit) do |issue_raw|
                 # https://github.com/dorack/jiralicious/blob/v0.4.0/lib/jiralicious/search_result.rb#L32-34
                 begin
                   issue = find_issue(issue_raw["key"])

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -194,15 +194,6 @@ describe Embulk::Input::JiraApi::Client do
       expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
     end
 
-    it "current_limit = 50, all_items = 50, fail_items=50, times=1" do
-      current_limit = 50
-      all_items = 50
-      fail_items = 50
-      times = 1
-      expected_result = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
-      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
-    end
-
     it "current_limit = MIN_RATE_LIMIT, all_items = 50, fail_items=20, times=2" do
       current_limit = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
       all_items = 50

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -173,4 +173,61 @@ describe Embulk::Input::JiraApi::Client do
       end
     end
   end
+
+  describe "#calculate_rate_limit" do
+    let(:jira_api) { Embulk::Input::JiraApi::Client.new }
+    it "current_limit = 50, all_items = 50, fail_items=50, times=1" do
+      current_limit = 50
+      all_items = 50
+      fail_items = 50
+      times = 1
+      expected_result = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+
+    it "current_limit = 50, all_items = 50, fail_items=20, times=1" do
+      current_limit = 50
+      all_items = 50
+      fail_items = 20
+      times = 1
+      expected_result = 20
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+
+    it "current_limit = 50, all_items = 50, fail_items=50, times=1" do
+      current_limit = 50
+      all_items = 50
+      fail_items = 50
+      times = 1
+      expected_result = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+
+    it "current_limit = MIN_RATE_LIMIT, all_items = 50, fail_items=20, times=2" do
+      current_limit = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
+      all_items = 50
+      fail_items = 20
+      times = 2
+      expected_result = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+
+    it "current_limit = 10, all_items = 30, fail_items=25, times=2" do
+      current_limit = 10
+      all_items = 30
+      fail_items = 25
+      times = 2
+      expected_result = 5
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+
+    it "current_limit = 50, all_items = 50, fail_items=20, times=DEFAULT_SEARCH_RETRY_TIMES/2" do
+      current_limit = 50
+      all_items = 50
+      fail_items = 20
+      times = Embulk::Input::JiraApi::Client::DEFAULT_SEARCH_RETRY_TIMES/2
+      expected_result = Embulk::Input::JiraApi::Client::MIN_RATE_LIMIT
+      expect(jira_api.calculate_rate_limit(current_limit, all_items, fail_items, times)).to eq expected_result
+    end
+  end
 end

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -81,7 +81,7 @@ describe Embulk::Input::JiraApi::Client do
 
     it "Search issues got 401 due to high concurrent load issues" do
       allow(Jiralicious).to receive_message_chain(:search, :issues_raw).and_return(results)
-      allow(Jiralicious::Issue).to receive(:find){ MultiJson.load("<title>#{title_401}</title>")}
+      allow(jira_api).to receive(:find_issue){ MultiJson.load("<title>#{title_401}</title>")}
       allow(jira_api).to receive(:sleep)
 
       expect { subject }.to raise_error(StandardError, title_401)

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -30,7 +30,7 @@ describe Embulk::Input::JiraApi::Client do
       end
 
       it "retry DEFAULT_SEARCH_RETRY_TIMES times then raise error" do
-        expect(Timeout).to receive(:timeout).exactly(Embulk::Input::JiraApi::Client::DEFAULT_SEARCH_RETRY_TIMES)
+        expect(Timeout).to receive(:timeout).exactly(Embulk::Input::JiraApi::Client::DEFAULT_SEARCH_RETRY_TIMES + 1)
         expect { subject }.to raise_error
       end
     end
@@ -120,7 +120,7 @@ describe Embulk::Input::JiraApi::Client do
     it "Always timeout, raise error after N times retry" do
       allow(Timeout).to receive(:timeout) { raise Timeout::Error }
 
-      expect(Timeout).to receive(:timeout).with(wait).exactly(retry_times).times
+      expect(Timeout).to receive(:timeout).with(wait).exactly(retry_times + 1).times
       expect { subject }.to raise_error(Timeout::Error)
     end
 

--- a/spec/embulk/input/jira_api/client_spec.rb
+++ b/spec/embulk/input/jira_api/client_spec.rb
@@ -73,7 +73,7 @@ describe Embulk::Input::JiraApi::Client do
 
     it "Search issues successfully" do
       allow(Jiralicious).to receive_message_chain(:search, :issues_raw).and_return(results)
-      allow(Jiralicious::Issue).to receive(:find).and_return(results.first)
+      allow(jira_api).to receive(:find_issue).and_return(results.first)
 
       expect(subject).to be_kind_of Array
       expect(subject.map(&:class)).to match_array [Embulk::Input::JiraApi::Issue, Embulk::Input::JiraApi::Issue]


### PR DESCRIPTION
Currently, depends on the user account, we could got HTTP 401 Error when we call JIRA APIs so frequently (Although the credential is correct). 

This PRs try to solve the above problem by : 
1. Dynamically calculate the number of parallel threads to reduce the risk of 401
2. Add a rate limiter to limit the number of requests to send per 2 seconds
3. Retry search only failed issues