### PR TITLE
Fix hang when validate task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.8 - 2019-04-08
+
+* [fixed] Process is hang forever when validate task [#56](https://github.com/treasure-data/embulk-input-jira/pull/56)
+
 ## 0.2.7 - 2019-03-05
 
 * [enhancement] Support empty JQL [#55](https://github.com/treasure-data/embulk-input-jira/pull/55)

--- a/build.gradle
+++ b/build.gradle
@@ -9,15 +9,12 @@ import com.github.jrubygradle.JRubyExec
 repositories {
     mavenCentral()
     jcenter()
-    maven {
-        url "https://dl.bintray.com/embulk-base-restclient/maven"
-    }
 }
 configurations {
     provided
 }
 
-version = "0.2.7"
+version = "0.2.8"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -25,7 +22,6 @@ targetCompatibility = 1.8
 dependencies {
     compile  "org.embulk:embulk-core:0.9.11"
     provided "org.embulk:embulk-core:0.9.11"
-    compile  "org.embulk.base.restclient:embulk-util-retryhelper-jetty92:0.6.0"
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
     compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.27'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'

--- a/src/main/java/org/embulk/input/jira/Constant.java
+++ b/src/main/java/org/embulk/input/jira/Constant.java
@@ -7,6 +7,7 @@ public final class Constant
     public static final int GUESS_RECORDS_COUNT = 50;
     public static final int PREVIEW_RECORDS_COUNT = 10;
     public static final int GUESS_BUFFER_SIZE = 5 * 1024 * 1024;
+    public static final int HTTP_TIMEOUT = 300 * 1000;
 
     public static final String DEFAULT_TIMESTAMP_PATTERN = "%Y-%m-%dT%H:%M:%S.%L%z";
 

--- a/src/main/java/org/embulk/input/jira/client/JiraClient.java
+++ b/src/main/java/org/embulk/input/jira/client/JiraClient.java
@@ -197,13 +197,14 @@ public class JiraClient
     @VisibleForTesting
     public CloseableHttpClient createHttpClient()
     {
-        RequestConfig config = RequestConfig.custom()
-                .setConnectTimeout(HTTP_TIMEOUT)
-                .setConnectionRequestTimeout(HTTP_TIMEOUT)
-                .setSocketTimeout(HTTP_TIMEOUT)
-                .setCookieSpec(CookieSpecs.STANDARD)
-                .build();
-        return HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+        return HttpClientBuilder.create()
+                    .setDefaultRequestConfig(RequestConfig.custom()
+                                                        .setConnectTimeout(HTTP_TIMEOUT)
+                                                        .setConnectionRequestTimeout(HTTP_TIMEOUT)
+                                                        .setSocketTimeout(HTTP_TIMEOUT)
+                                                        .setCookieSpec(CookieSpecs.STANDARD)
+                                                        .build())
+                    .build();
     }
 
     private HttpRequestBase createPostRequest(PluginTask task, String url, String body) throws IOException

--- a/src/main/java/org/embulk/input/jira/client/JiraClient.java
+++ b/src/main/java/org/embulk/input/jira/client/JiraClient.java
@@ -8,14 +8,15 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.embulk.config.ConfigException;
@@ -40,14 +41,13 @@ import static java.util.Base64.getEncoder;
 import static org.apache.http.HttpHeaders.ACCEPT;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.embulk.input.jira.Constant.HTTP_TIMEOUT;
 import static org.embulk.input.jira.Constant.MIN_RESULTS;
 import static org.embulk.spi.util.RetryExecutor.retryExecutor;
 
 public class JiraClient
 {
     public JiraClient() {}
-
-    private static final int CONNECTION_TIME_OUT = 300000;
 
     private static final Logger LOGGER = Exec.getLogger(JiraClient.class);
 
@@ -157,8 +157,7 @@ public class JiraClient
 
     private String authorizeAndRequest(final PluginTask task, String url, String body) throws JiraException
     {
-        try {
-            HttpClient client = createHttpClient();
+        try (CloseableHttpClient client = createHttpClient()) {
             HttpRequestBase request;
             if (body == null) {
                 request = createGetRequest(task, url);
@@ -166,13 +165,14 @@ public class JiraClient
             else {
                 request = createPostRequest(task, url, body);
             }
-            HttpResponse response = client.execute(request);
-            // Check for HTTP response code : 200 : SUCCESS
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != HttpStatus.SC_OK) {
-                throw new JiraException(statusCode, extractErrorMessages(EntityUtils.toString(response.getEntity())));
+            try (CloseableHttpResponse response = client.execute(request)) {
+             // Check for HTTP response code : 200 : SUCCESS
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode != HttpStatus.SC_OK) {
+                    throw new JiraException(statusCode, extractErrorMessages(EntityUtils.toString(response.getEntity())));
+                }
+                return EntityUtils.toString(response.getEntity());
             }
-            return EntityUtils.toString(response.getEntity());
         }
         catch (IOException e) {
             throw new JiraException(-1, e.getMessage());
@@ -195,11 +195,13 @@ public class JiraClient
     }
 
     @VisibleForTesting
-    public HttpClient createHttpClient()
+    public CloseableHttpClient createHttpClient()
     {
         RequestConfig config = RequestConfig.custom()
-                .setConnectTimeout(CONNECTION_TIME_OUT)
-                .setConnectionRequestTimeout(CONNECTION_TIME_OUT)
+                .setConnectTimeout(HTTP_TIMEOUT)
+                .setConnectionRequestTimeout(HTTP_TIMEOUT)
+                .setSocketTimeout(HTTP_TIMEOUT)
+                .setCookieSpec(CookieSpecs.STANDARD)
                 .build();
         return HttpClientBuilder.create().setDefaultRequestConfig(config).build();
     }

--- a/src/main/java/org/embulk/input/jira/util/JiraUtil.java
+++ b/src/main/java/org/embulk/input/jira/util/JiraUtil.java
@@ -74,7 +74,7 @@ public final class JiraUtil
                                                                                 .setCookieSpec(CookieSpecs.STANDARD)
                                                                                 .build())
                                             .build()) {
-            HttpGet request = new HttpGet(task.getUri());
+            HttpGet request = new HttpGet(uri);
             try (CloseableHttpResponse response = client.execute(request)) {
                 response.getStatusLine().getStatusCode();
             }

--- a/src/test/java/org/embulk/input/jira/JiraInputPluginTest.java
+++ b/src/test/java/org/embulk/input/jira/JiraInputPluginTest.java
@@ -3,11 +3,11 @@ package org.embulk.input.jira;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -42,8 +42,8 @@ public class JiraInputPluginTest
     private JiraClient jiraClient;
     private JsonObject data;
     private ConfigSource config;
-    private HttpClient client = Mockito.mock(HttpClient.class);
-    private HttpResponse response = Mockito.mock(HttpResponse.class);
+    private CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+    private CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
     private StatusLine statusLine = Mockito.mock(StatusLine.class);
 
     private MockPageOutput output = new MockPageOutput();

--- a/src/test/java/org/embulk/input/jira/client/JiraClientTest.java
+++ b/src/test/java/org/embulk/input/jira/client/JiraClientTest.java
@@ -2,10 +2,10 @@ package org.embulk.input.jira.client;
 
 import com.google.gson.JsonObject;
 
-import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
@@ -34,8 +34,8 @@ public class JiraClientTest
     private JiraClient jiraClient;
     private PluginTask task;
 
-    private HttpClient client = Mockito.mock(HttpClient.class);
-    private HttpResponse response = Mockito.mock(HttpResponse.class);
+    private CloseableHttpClient client = Mockito.mock(CloseableHttpClient.class);
+    private CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
     private StatusLine statusLine = Mockito.mock(StatusLine.class);
     private JsonObject data;
 
@@ -44,7 +44,7 @@ public class JiraClientTest
     {
         if (jiraClient == null) {
             jiraClient = Mockito.spy(new JiraClient());
-            response = Mockito.mock(HttpResponse.class);
+            response = Mockito.mock(CloseableHttpResponse.class);
             task = TestHelpers.config().loadConfig(PluginTask.class);
             data = TestHelpers.getJsonFromFile("jira_client.json");
         }

--- a/src/test/java/org/embulk/input/jira/util/JiraUtilTest.java
+++ b/src/test/java/org/embulk/input/jira/util/JiraUtilTest.java
@@ -21,9 +21,7 @@ import org.msgpack.value.Value;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -111,148 +109,148 @@ public class JiraUtilTest
     }
 
     @Test
-    public void test_validateTaskConfig() throws IOException
+    public void test_validateTaskConfig_allValid() throws IOException
     {
-        // Happy case
         ConfigSource configSource = TestHelpers.config();
         PluginTask task = configSource.loadConfig(PluginTask.class);
-        Exception exception = null;
-        try {
-            JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNull(exception);
+        JiraUtil.validateTaskConfig(task);
+    }
 
-        // empty username
-        configSource = TestHelpers.config();
-        configSource.set("username", "");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_emptyUsername() throws IOException
+    {
+        ConfigException exception = assertThrows("Username or email could not be empty", ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("username", "");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("Username or email could not be empty", exception.getMessage());
+    }
 
-        // empty password
-        configSource = TestHelpers.config();
-        configSource.set("password", "");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_emptyPassword() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("password", "");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("Password could not be empty", exception.getMessage());
+    }
 
-        // empty uri
-        configSource = TestHelpers.config();
-        configSource.set("uri", "");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_emptyUri() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("uri", "");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("JIRA API endpoint could not be empty", exception.getMessage());
+    }
 
-        // invalid uri
-        configSource = TestHelpers.config();
-        configSource.set("uri", "https://not-existed-domain");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_nonExistedUri() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("uri", "https://not-existed-domain");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("JIRA API endpoint is incorrect or not available", exception.getMessage());
+    }
 
-        // empty jql
-        configSource = TestHelpers.config();
+    @Test
+    public void test_validateTaskConfig_invalidUriProtocol() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("uri", "ftp://example.com");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
+            JiraUtil.validateTaskConfig(task);
+        });
+        assertEquals("JIRA API endpoint is incorrect or not available", exception.getMessage());
+    }
+
+    @Test
+    public void test_validateTaskConfig_containSpaceUri() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("uri", "https://example .com");
+            PluginTask task = configSource.loadConfig(PluginTask.class);
+            JiraUtil.validateTaskConfig(task);
+        });
+        assertEquals("JIRA API endpoint is incorrect or not available", exception.getMessage());
+    }
+
+    @Test
+    public void test_validateTaskConfig_emptyJql() throws IOException
+    {
+        ConfigSource configSource = TestHelpers.config();
         configSource.set("jql", "");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
-            JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNull(exception);
+        PluginTask task = configSource.loadConfig(PluginTask.class);
+        JiraUtil.validateTaskConfig(task);
+    }
 
-        configSource = TestHelpers.config();
+    @Test
+    public void test_validateTaskConfig_missingJql() throws IOException
+    {
+        ConfigSource configSource = TestHelpers.config();
         configSource.remove("jql");
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
-            JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNull(exception);
+        PluginTask task = configSource.loadConfig(PluginTask.class);
+        JiraUtil.validateTaskConfig(task);
+    }
 
-        // initial_retry_interval_millis = 0
-        configSource = TestHelpers.config();
-        configSource.set("initial_retry_interval_millis", 0);
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_RetryIntervalIs0() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("initial_retry_interval_millis", 0);
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("Initial retry delay should be equal or greater than 1", exception.getMessage());
+    }
 
-        // retry_limit = -1
-        configSource = TestHelpers.config();
-        configSource.set("retry_limit", -1);
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_RetryIntervalIsNegative() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("initial_retry_interval_millis", -1);
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
+        assertEquals("Initial retry delay should be equal or greater than 1", exception.getMessage());
+    }
+
+    @Test
+    public void test_validateTaskConfig_RetryLimitGreaterThan10() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("retry_limit", 11);
+            PluginTask task = configSource.loadConfig(PluginTask.class);
+            JiraUtil.validateTaskConfig(task);
+        });
         assertEquals("Retry limit should between 0 and 10", exception.getMessage());
+    }
 
-        // retry_limit = 100
-        configSource = TestHelpers.config();
-        configSource.set("retry_limit", 100);
-        task = configSource.loadConfig(PluginTask.class);
-        exception = null;
-        try {
+    @Test
+    public void test_validateTaskConfig_RetryLimitLessThan0() throws IOException
+    {
+        ConfigException exception = assertThrows(ConfigException.class, () -> {
+            ConfigSource configSource = TestHelpers.config();
+            configSource.set("retry_limit", -1);
+            PluginTask task = configSource.loadConfig(PluginTask.class);
             JiraUtil.validateTaskConfig(task);
-        }
-        catch (Exception e) {
-            exception = e;
-        }
-        assertNotNull(exception);
-        assertTrue(exception instanceof ConfigException);
+        });
         assertEquals("Retry limit should between 0 and 10", exception.getMessage());
     }
 


### PR DESCRIPTION
Problem:
* When validate the task in jira, we try to ping the host. However, because of missing setConnectTimeout property for the HttpURLConnection then when request timeout, the plugin will hang forever.

Solution:
* Using apache http client with proper timeout - connection timeout and socket time out to ping the host