### PR TITLE
Remove ConfigSource#getObjectNode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: java
 
 jdk: oraclejdk8
 
+dist: trusty 
+
 env:
   global:
     secure: "NCkU3f60cn5Gmzq+NwDmKdQSq+ApF/rPqSHPirk1+ZPW9n+H9912meUuJr9qyn03MPdc6wAQinsl3skdPNh1Qz02TI/WZGMiCQTLh3nKIMzaaxx6I+OZ1TV7A4MoJMQ7oYQdXdbvRYXpOVRnfVDxpUC+BDk2T8xmjfm9cht+PGTzM6RxpmSL842hiudkcyxHxgEf66EGpi6h2G2PqYNfQrksqiVMWlLiTO5a2ee+iw9qTMhgKrhEKLCb+dFB56gtKIOpd3MxieLwf3PDcsjM+TSaWo6Bp+mjdA3zGJNz5wbWRVSdrIvKvxmf3eRqAGssBhBDO/LUN3LnI+/T/7J9XZZd7WXNudo/t6HQXhJkUIvOucCxSg8/uRsxrMAmF2zkJOnYGSvN3HNqdzyz86TK4/Xckl+gX51b0uYncHfZYSojn4py1RWPYpX/L2RHbzMn1MJ7B3/VZ21vY97aHhDgNyyAMxPnTAuR1IZicEgA8y8AmZkkK9tWq5wvAOKI91V+W8iBEaO2dZIib+KdJSUUj/Q3TM3i4wX9O/AU7tknsnCApvxQeveELJ4SxfFd/Z2imqmQWM0wIgp1u7Vjguf8kSaxcuQHonZNdwvvYOkbYxHvUqltzlmE1qFC/kQe6o9fS3NuiugHCYVeFs+LXVVW+nl0pWztFYMicUmQq7T781w="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.9 - 2019-11-17
+
+* [enhancement] Remove usage of `ConfigSource#getObjectNode` [#57](https://github.com/treasure-data/embulk-input-jira/pull/57)
+
 ## 0.2.8 - 2019-04-08
 
 * [fixed] Process is hang forever when validate task [#56](https://github.com/treasure-data/embulk-input-jira/pull/56)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ embulk-input-jira is the Embulk input plugin for [JIRA](https://www.atlassian.co
 
 ## Overview
 
-Required Embulk version >= 0.8.7
+Required Embulk version >= 0.9.20
 
 * **Plugin type**: input
 * **Resume supported**: no

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.2.8"
+version = "0.2.9"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.2.9.alpha.01"
+version = "0.2.9"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -20,15 +20,15 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.9.11"
-    provided "org.embulk:embulk-core:0.9.11"
+    compile  "org.embulk:embulk-core:0.9.20"
+    provided "org.embulk:embulk-core:0.9.20"
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.6'
     compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: '2.27'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
     testCompile "junit:junit:4.+"
     testCompile "org.mockito:mockito-core:2.+"
-    testCompile "org.embulk:embulk-test:0.9.11"
-    testCompile "org.embulk:embulk-core:0.9.11:tests"
+    testCompile "org.embulk:embulk-test:0.9.20"
+    testCompile "org.embulk:embulk-core:0.9.20:tests"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.2.9"
+version = "0.2.9.alpha.01"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
+++ b/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
@@ -162,7 +162,7 @@ public class JiraInputPlugin
         Buffer sample = Buffer.copyOf(createSamples(issues, getUniqueAttributes(issues)).toString().getBytes());
         JsonNode columns = Exec.getInjector().getInstance(GuessExecutor.class)
                                 .guessParserConfig(sample, Exec.newConfigSource(), createGuessConfig())
-                                .getObjectNode().get("columns");
+                                .get(JsonNode.class, "columns");
         return Exec.newConfigDiff().set("columns", columns);
     }
 

--- a/src/main/java/org/embulk/input/jira/util/JiraUtil.java
+++ b/src/main/java/org/embulk/input/jira/util/JiraUtil.java
@@ -9,6 +9,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.embulk.config.ConfigException;
+import org.embulk.config.ConfigSource;
 import org.embulk.input.jira.Issue;
 import org.embulk.input.jira.JiraInputPlugin.PluginTask;
 import org.embulk.spi.Column;
@@ -37,32 +38,32 @@ public final class JiraUtil
 {
     private JiraUtil() {}
 
-    public static int calculateTotalPage(int totalCount, int resultPerPage)
+    public static int calculateTotalPage(final int totalCount, final int resultPerPage)
     {
         return (int) Math.ceil((double) totalCount / resultPerPage);
     }
 
-    public static String buildPermissionUrl(String url)
+    public static String buildPermissionUrl(final String url)
     {
         return UriBuilder.fromUri(url).path(CREDENTIAL_URI_PATH).build().toString();
     }
 
-    public static String buildSearchUrl(String url)
+    public static String buildSearchUrl(final String url)
     {
         return UriBuilder.fromUri(url).path(SEARCH_URI_PATH).build().toString();
     }
 
     public static void validateTaskConfig(final PluginTask task)
     {
-        String username = task.getUsername();
+        final String username = task.getUsername();
         if (isNullOrEmpty(username)) {
             throw new ConfigException("Username or email could not be empty");
         }
-        String password = task.getPassword();
+        final String password = task.getPassword();
         if (isNullOrEmpty(password)) {
             throw new ConfigException("Password could not be empty");
         }
-        String uri = task.getUri();
+        final String uri = task.getUri();
         if (isNullOrEmpty(uri)) {
             throw new ConfigException("JIRA API endpoint could not be empty");
         }
@@ -74,7 +75,7 @@ public final class JiraUtil
                                                                                 .setCookieSpec(CookieSpecs.STANDARD)
                                                                                 .build())
                                             .build()) {
-            HttpGet request = new HttpGet(uri);
+            final HttpGet request = new HttpGet(uri);
             try (CloseableHttpResponse response = client.execute(request)) {
                 response.getStatusLine().getStatusCode();
             }
@@ -82,11 +83,11 @@ public final class JiraUtil
         catch (IOException | IllegalArgumentException e) {
             throw new ConfigException("JIRA API endpoint is incorrect or not available");
         }
-        int retryInitialWaitSec = task.getInitialRetryIntervalMillis();
+        final int retryInitialWaitSec = task.getInitialRetryIntervalMillis();
         if (retryInitialWaitSec < 1) {
             throw new ConfigException("Initial retry delay should be equal or greater than 1");
         }
-        int retryLimit = task.getRetryLimit();
+        final int retryLimit = task.getRetryLimit();
         if (retryLimit < 0 || retryLimit > 10) {
             throw new ConfigException("Retry limit should between 0 and 10");
         }
@@ -96,26 +97,25 @@ public final class JiraUtil
      * For getting the timestamp value of the node
      * Sometime if the parser could not parse the value then return null
      * */
-    private static Timestamp getTimestampValue(PluginTask task, Column column, String value)
+    private static Timestamp getTimestampValue(final PluginTask task, final Column column, final String value)
     {
-        List<ColumnConfig> columnConfigs = task.getColumns().getColumns();
+        final List<ColumnConfig> columnConfigs = task.getColumns().getColumns();
         String pattern = DEFAULT_TIMESTAMP_PATTERN;
-        for (ColumnConfig config : columnConfigs) {
+        for (final ColumnConfig config : columnConfigs) {
+            final ConfigSource columnConfig = config.getConfigSource();
             if (config.getName().equals(column.getName())
-                    && config.getConfigSource() != null
-                    && config.getConfigSource().getObjectNode() != null
-                    && config.getConfigSource().getObjectNode().get("format") != null
-                    && config.getConfigSource().getObjectNode().get("format").isTextual()) {
-                pattern = config.getConfigSource().getObjectNode().get("format").asText();
+                    && columnConfig != null
+                    && columnConfig.has("format")) {
+                pattern = columnConfig.get(String.class, "format");
                 break;
             }
         }
-        TimestampParser parser = TimestampParser.of(pattern, "UTC");
+        final TimestampParser parser = TimestampParser.of(pattern, "UTC");
         Timestamp result = null;
         try {
             result = parser.parse(value);
         }
-        catch (Exception e) {
+        catch (final Exception e) {
         }
         return result;
     }
@@ -124,13 +124,13 @@ public final class JiraUtil
      * For getting the Long value of the node
      * Sometime if error occurs (i.e a JSON value but user modified it as long) then return null
      * */
-    private static Long getLongValue(JsonElement value)
+    private static Long getLongValue(final JsonElement value)
     {
         Long result = null;
         try {
             result = value.getAsLong();
         }
-        catch (Exception e) {
+        catch (final Exception e) {
         }
         return result;
     }
@@ -139,13 +139,13 @@ public final class JiraUtil
      * For getting the Double value of the node
      * Sometime if error occurs (i.e a JSON value but user modified it as double) then return null
      * */
-    private static Double getDoubleValue(JsonElement value)
+    private static Double getDoubleValue(final JsonElement value)
     {
         Double result = null;
         try {
             result = value.getAsDouble();
         }
-        catch (Exception e) {
+        catch (final Exception e) {
         }
         return result;
     }
@@ -154,24 +154,24 @@ public final class JiraUtil
      * For getting the Boolean value of the node
      * Sometime if error occurs (i.e a JSON value but user modified it as boolean) then return null
      * */
-    private static Boolean getBooleanValue(JsonElement value)
+    private static Boolean getBooleanValue(final JsonElement value)
     {
         Boolean result = null;
         try {
             result = value.getAsBoolean();
         }
-        catch (Exception e) {
+        catch (final Exception e) {
         }
         return result;
     }
 
-    public static void addRecord(Issue issue, Schema schema, PluginTask task, PageBuilder pageBuilder)
+    public static void addRecord(final Issue issue, final Schema schema, final PluginTask task, final PageBuilder pageBuilder)
     {
         schema.visitColumns(new ColumnVisitor() {
             @Override
-            public void jsonColumn(Column column)
+            public void jsonColumn(final Column column)
             {
-                JsonElement data = issue.getValue(column.getName());
+                final JsonElement data = issue.getValue(column.getName());
                 if (data.isJsonNull() || data.isJsonPrimitive()) {
                     pageBuilder.setNull(column);
                 }
@@ -181,9 +181,9 @@ public final class JiraUtil
             }
 
             @Override
-            public void stringColumn(Column column)
+            public void stringColumn(final Column column)
             {
-                JsonElement data = issue.getValue(column.getName());
+                final JsonElement data = issue.getValue(column.getName());
                 if (data.isJsonNull()) {
                     pageBuilder.setNull(column);
                 }
@@ -208,14 +208,14 @@ public final class JiraUtil
             }
 
             @Override
-            public void timestampColumn(Column column)
+            public void timestampColumn(final Column column)
             {
-                JsonElement data = issue.getValue(column.getName());
+                final JsonElement data = issue.getValue(column.getName());
                 if (data.isJsonNull() || data.isJsonObject() || data.isJsonArray()) {
                     pageBuilder.setNull(column);
                 }
                 else {
-                    Timestamp value = getTimestampValue(task, column, data.getAsString());
+                    final Timestamp value = getTimestampValue(task, column, data.getAsString());
                     if (value == null) {
                         pageBuilder.setNull(column);
                     }
@@ -226,9 +226,9 @@ public final class JiraUtil
             }
 
             @Override
-            public void booleanColumn(Column column)
+            public void booleanColumn(final Column column)
             {
-                Boolean value = getBooleanValue(issue.getValue(column.getName()));
+                final Boolean value = getBooleanValue(issue.getValue(column.getName()));
                 if (value == null) {
                     pageBuilder.setNull(column);
                 }
@@ -238,9 +238,9 @@ public final class JiraUtil
             }
 
             @Override
-            public void longColumn(Column column)
+            public void longColumn(final Column column)
             {
-                Long value = getLongValue(issue.getValue(column.getName()));
+                final Long value = getLongValue(issue.getValue(column.getName()));
                 if (value == null) {
                     pageBuilder.setNull(column);
                 }
@@ -250,9 +250,9 @@ public final class JiraUtil
             }
 
             @Override
-            public void doubleColumn(Column column)
+            public void doubleColumn(final Column column)
             {
-                Double value = getDoubleValue(issue.getValue(column.getName()));
+                final Double value = getDoubleValue(issue.getValue(column.getName()));
                 if (value == null) {
                     pageBuilder.setNull(column);
                 }

--- a/src/main/java/org/embulk/input/jira/util/JiraUtil.java
+++ b/src/main/java/org/embulk/input/jira/util/JiraUtil.java
@@ -101,12 +101,12 @@ public final class JiraUtil
     {
         final List<ColumnConfig> columnConfigs = task.getColumns().getColumns();
         String pattern = DEFAULT_TIMESTAMP_PATTERN;
-        for (final ColumnConfig config : columnConfigs) {
-            final ConfigSource columnConfig = config.getConfigSource();
-            if (config.getName().equals(column.getName())
-                    && columnConfig != null
-                    && columnConfig.has("format")) {
-                pattern = columnConfig.get(String.class, "format");
+        for (final ColumnConfig columnConfig : columnConfigs) {
+            final ConfigSource columnConfigSource = columnConfig.getConfigSource();
+            if (columnConfig.getName().equals(column.getName())
+                    && columnConfigSource != null
+                    && columnConfigSource.has("format")) {
+                pattern = columnConfigSource.get(String.class, "format");
                 break;
             }
         }


### PR DESCRIPTION
Since Embulk will deprecate `ConfigSource#getObjectNode` so this PR will remove these usage out of `embulk-input-jira` plugin