### PR TITLE
Support dynamic schema when ingesting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.13 - 2021-09-30
+* [enhancement] Support dynamic schema
+* PR [#69](https://github.com/treasure-data/embulk-input-jira/pull/69)
+
 ## 0.2.12 - 2021-08-24
 * [enhancement] Mordernized with embulk v0.10.x styles
 * [enhancement] Use embulk-guess-util

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Required Embulk version >= 0.10.19
 - **password** JIRA password or API keys (string, required)
 - **uri** JIRA API endpoint (string, required)
 - **jql** [JQL](https://confluence.atlassian.com/display/JIRA/Advanced+Searching) for extract target issues (string, required)
+- **dynamic_schema** Used it to refresh the schema each time ingestion (boolean, default: `false`)
 - **columns** target issue attributes. You can generate this configuration by `guess` command (array, required)
 - **retry_initial_wait_sec**: Wait seconds for exponential backoff initial value (integer, default: 1)
 - **retry_limit**: Try to retry this times (integer, default: 5)
@@ -48,4 +49,10 @@ in:
 
 ```
 $ ./gradlew gem       # -t to watch change of files and rebuild continuously
+```
+
+## Test
+
+```
+$ ./gradlew checkstyle test jacocoTestReport
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     jcenter()
 }
 
-version = "0.2.12"
+version = "0.2.13"
 group = "com.treasuredata.embulk.plugins"
 description = "JIRA Embulk input plugin."
 

--- a/src/test/java/org/embulk/input/jira/TestHelpers.java
+++ b/src/test/java/org/embulk/input/jira/TestHelpers.java
@@ -55,5 +55,10 @@ public final class TestHelpers
                 }));
     }
 
+    public static ConfigSource dynamicSchemaConfig()
+    {
+        return config().set("dynamic_schema", true);
+    }
+
     private static final ConfigSource EMPTY_CONFIG_SOURCE = CONFIG_MAPPER_FACTORY.newConfigSource();
 }


### PR DESCRIPTION
Due to JIRA ticket's fields always changed it schema, so introduce a new option for fetching the newest schema each time rather on based on pre-configured `columns`