### PR TITLE
Graceful shutdown in case no records for dynamic schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.14 - 2021-10-12
+* [enhancement] Graceful exit in case no data of dynamic schema
+* PR [#70](https://github.com/treasure-data/embulk-input-jira/pull/70)
+
 ## 0.2.13 - 2021-09-30
 * [enhancement] Support dynamic schema
 * PR [#69](https://github.com/treasure-data/embulk-input-jira/pull/69)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     jcenter()
 }
 
-version = "0.2.13"
+version = "0.2.14"
 group = "com.treasuredata.embulk.plugins"
 description = "JIRA Embulk input plugin."
 

--- a/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
+++ b/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
@@ -109,9 +109,16 @@ public class JiraInputPlugin
         if (task.getDynamicSchema()) {
             final JiraClient jiraClient = getJiraClient();
             final List<ColumnConfig> columns = new ArrayList<>();
-            final List<ConfigDiff> guessedColumns = getGuessedColumns(jiraClient, task);
-            for (final ConfigDiff guessedColumn : guessedColumns) {
-                columns.add(new ColumnConfig(CONFIG_MAPPER_FACTORY.newConfigSource().merge(guessedColumn)));
+            try {
+                final List<ConfigDiff> guessedColumns = getGuessedColumns(jiraClient, task);
+                for (final ConfigDiff guessedColumn : guessedColumns) {
+                    columns.add(new ColumnConfig(CONFIG_MAPPER_FACTORY.newConfigSource().merge(guessedColumn)));
+                }
+            }
+            catch (final ConfigException e) {
+                if (!e.getMessage().equals("Could not guess schema due to empty data set")) {
+                    throw e;
+                }
             }
             schemaConfig = new SchemaConfig(columns);
         }

--- a/src/test/java/org/embulk/input/jira/JiraInputPluginTest.java
+++ b/src/test/java/org/embulk/input/jira/JiraInputPluginTest.java
@@ -10,7 +10,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
-import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
@@ -90,7 +89,6 @@ public class JiraInputPluginTest
         verify(pageBuilder, times(1)).finish();
     }
 
-    @Test(expected = ConfigException.class)
     public void test_runDynamicSchema_withEmptyResult() throws IOException
     {
         final JsonObject searchResponse = data.get("emptyResult").getAsJsonObject();
@@ -99,8 +97,8 @@ public class JiraInputPluginTest
                 .thenReturn(searchResponse.get("statusCode").getAsInt());
         when(response.getEntity())
                 .thenReturn(new StringEntity(searchResponse.get("body").toString()));
-
         plugin.transaction(TestHelpers.dynamicSchemaConfig(), new Control());
+        verify(pageBuilder, times(0)).addRecord();
     }
 
     @Test


### PR DESCRIPTION
Current when `no data` in `dynamic schema` runs, plugin will throw `ConfigException`.
This PR is aimed to resolve this problem by exit the jobs at successfully.