### PR TITLE
Catchup with embulk 0.10.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.15 - 2022-05-23
+* [enhancement] Catchup with embulk v0.10.32
+* PR [#71](https://github.com/treasure-data/embulk-input-jira/pull/71)
+
 ## 0.2.14 - 2021-10-12
 * [enhancement] Graceful exit in case no data of dynamic schema
 * PR [#70](https://github.com/treasure-data/embulk-input-jira/pull/70)

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
     jcenter()
 }
 
-version = "0.2.14"
+version = "0.2.15"
 group = "com.treasuredata.embulk.plugins"
 description = "JIRA Embulk input plugin."
 

--- a/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
+++ b/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
@@ -172,7 +172,7 @@ public class JiraInputPlugin
     public ConfigDiff guess(final ConfigSource config)
     {
         // Reset columns in case already have or missing on configuration
-        config.set("columns", new ObjectMapper().createArrayNode());
+        config.set("columns", new ArrayList<>());
         final PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
         JiraUtil.validateTaskConfig(task);
         final JiraClient jiraClient = getJiraClient();

--- a/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
+++ b/src/main/java/org/embulk/input/jira/JiraInputPlugin.java
@@ -1,6 +1,5 @@
 package org.embulk.input.jira;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;


### PR DESCRIPTION
Replace ObjectMapper().createArrayNode() to new new ArrayList<>() to catchup with embulk v0.10.32.
 