### PR TITLE
Update upload artifact to v4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build with testing
         run: ./gradlew check --console rich --info
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tests
@@ -34,7 +34,7 @@ jobs:
         if: success()
         run: ./gradlew jacocoTestReport
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success()
         with:
           name: jacoco


### PR DESCRIPTION
From https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact

```
Warning

actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.
```

We will need to update our version